### PR TITLE
Property pane controls with info icon and callout in the header: drop…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "test": "gulp test",
     "prepublishOnly": "gulp"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@microsoft/sp-core-library": "~1.3.0",
     "@microsoft/sp-webpart-base": "~1.3.0",

--- a/src/PropertyFieldDropdownInfoHeader.ts
+++ b/src/PropertyFieldDropdownInfoHeader.ts
@@ -1,0 +1,1 @@
+export * from './propertyFields/dropdownInfoHeader/index';

--- a/src/PropertyFieldHeader.ts
+++ b/src/PropertyFieldHeader.ts
@@ -1,0 +1,1 @@
+export * from './common/propertyFieldHeader/index';

--- a/src/PropertyFieldTextInfoHeader.ts
+++ b/src/PropertyFieldTextInfoHeader.ts
@@ -1,0 +1,1 @@
+export * from './propertyFields/textInfoHeader/index';

--- a/src/PropertyFieldToggleInfoHeader.ts
+++ b/src/PropertyFieldToggleInfoHeader.ts
@@ -1,0 +1,1 @@
+export * from './propertyFields/toggleInfoHeader/index';

--- a/src/common/propertyFieldHeader/IPropertyFieldHeader.ts
+++ b/src/common/propertyFieldHeader/IPropertyFieldHeader.ts
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+/**
+ * Enum to describe possible events to show callout
+ */
+export enum CalloutTriggers {
+    Click,
+    Hover
+}
+
+/**
+ * Interface that discibes available settings of Header callout
+ */
+export interface IPropertyFieldHeaderCalloutProps {
+    /**
+     * Callout content - any HTML
+    */
+    calloutContent?: React.ReactNode;
+    /**
+     * Custom width for callout including borders. If value is 0, no width is applied.
+     */
+    calloutWidth?: number;
+    /**
+     * Event to show the callout
+     */
+    calloutTrigger?: CalloutTriggers;
+    /**
+     * The gap between the Callout and the target
+     */
+    gapSpace?: number;
+}
+
+/**
+ * PropertyFieldHeader component props
+ */
+export interface IPropertyFieldHeaderProps extends IPropertyFieldHeaderCalloutProps {
+    /**
+     * The label to be shown in the header
+     */
+    label?: string;
+}
+
+/**
+ * PropertyFieldHeader component state
+ */
+export interface IPropertyFieldHeaderState {
+    /**
+     * Flag if the callout is currently visible
+     */
+    isCalloutVisible?: boolean;
+}

--- a/src/common/propertyFieldHeader/PropertyFieldHeader.module.scss
+++ b/src/common/propertyFieldHeader/PropertyFieldHeader.module.scss
@@ -1,0 +1,20 @@
+.headerBar {
+    position: relative;
+    margin-bottom: 5px;
+    .header {
+        margin-right: 24px;
+    }
+
+    .info {
+        position: absolute;
+        font-size: 14px;
+        background-color: transparent;
+        top: 3px;
+        right: 0px;
+        cursor: pointer;
+    }
+}
+
+.headerCallout {
+    padding: 10px;
+}

--- a/src/common/propertyFieldHeader/PropertyFieldHeader.tsx
+++ b/src/common/propertyFieldHeader/PropertyFieldHeader.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { IconButton, Callout, DirectionalHint } from 'office-ui-fabric-react';
+import { IPropertyFieldHeaderProps, IPropertyFieldHeaderState, CalloutTriggers } from './IPropertyFieldHeader';
+
+import styles from './PropertyFieldHeader.module.scss';
+
+/**
+ * PropertyFieldHeader component.
+ * Displays a label and a callout
+ */
+export default class PropertyFieldHeader extends React.Component<IPropertyFieldHeaderProps, IPropertyFieldHeaderState> {
+    
+        private _infoIcon: HTMLElement;
+    
+        public constructor(props: IPropertyFieldHeaderProps, state: IPropertyFieldHeaderState) {
+            super(props, state);
+            this._onCalloutDismiss = this._onCalloutDismiss.bind(this);
+            this.state = {
+                isCalloutVisible: false
+            };
+        }
+    
+        public render(): JSX.Element {
+            return (
+                <div className={styles.headerBar}>
+                    <div className={styles.header}>
+                        {this.props.label}
+                    </div>
+                    <div className={styles.info}>
+                        <i className={'ms-Icon ms-Icon--Info'} ref={(infoIcon) => { this._infoIcon = infoIcon; }}
+                            onMouseOver={this.props.calloutTrigger === CalloutTriggers.Hover ? this._onInfoIconMouseOver.bind(this) : null} 
+                            onMouseOut={this.props.calloutTrigger === CalloutTriggers.Hover ? this._onInfoIconMouseOut.bind(this) : null}
+                            onClick={this.props.calloutTrigger === CalloutTriggers.Click ? this._onInfoIconClick.bind(this) : null}></i>
+                    </div>
+                    {this.state.isCalloutVisible && (
+                        <Callout
+                            className={styles.headerCallout}
+                            target={this._infoIcon}
+                            isBeakVisible={true}
+                            directionalHint={DirectionalHint.leftCenter}
+                            directionalHintForRTL={DirectionalHint.rightCenter}
+                            onDismiss={this._onCalloutDismiss}
+                            gapSpace={this.props.gapSpace !== undefined ? this.props.gapSpace : 5}
+                            calloutWidth={this.props.calloutWidth}>
+                            {this.props.calloutContent}
+                        </Callout>
+                    )
+                    }
+                </div>);
+        }
+    
+    
+        private _onCalloutDismiss() {
+            if (this.state.isCalloutVisible) {
+                this.setState({
+                    isCalloutVisible: false
+                });
+            }
+        }
+        
+        private _onInfoIconMouseOver(): void {
+            if (this.props.calloutTrigger !== CalloutTriggers.Hover) {
+                return;
+            }
+
+            if (!this.state.isCalloutVisible) {
+                this.setState({
+                    isCalloutVisible: true
+                });
+            }
+        }
+    
+        private _onInfoIconMouseOut(e: MouseEvent): void {
+            if (this.props.calloutTrigger !== CalloutTriggers.Hover) {
+                return;
+            }
+
+            if (e.relatedTarget) {
+    
+                let relatedTarget: HTMLElement = (e.relatedTarget as HTMLElement);
+                if (relatedTarget && relatedTarget.closest('.ms-Callout-container')) {
+                    return;
+                }
+            }
+    
+            this.setState({
+                isCalloutVisible: false
+            });
+    
+        }
+
+        private _onInfoIconClick(): void {
+            if (this.props.calloutTrigger !== CalloutTriggers.Click) {
+                return;
+            }
+
+            this.setState({
+                isCalloutVisible: !this.state.isCalloutVisible
+            });
+        }
+    }

--- a/src/common/propertyFieldHeader/index.ts
+++ b/src/common/propertyFieldHeader/index.ts
@@ -1,0 +1,2 @@
+export * from './IPropertyFieldHeader';
+export * from './PropertyFieldHeader';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export * from './PropertyFieldPeoplePicker';
 export * from './PropertyFieldTermPicker';
 export * from './PropertyFieldColorPicker';
 export * from './PropertyFieldSpinButton';
+export * from './PropertyFieldDropdownInfoHeader';
+export * from './PropertyFieldTextInfoHeader';

--- a/src/propertyFields/dropdownInfoHeader/IPropertyFieldDropdownInfoHeader.ts
+++ b/src/propertyFields/dropdownInfoHeader/IPropertyFieldDropdownInfoHeader.ts
@@ -1,0 +1,19 @@
+import {
+    IPropertyPaneCustomFieldProps,
+    IPropertyPaneDropdownProps
+} from '@microsoft/sp-webpart-base';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+/**
+ * Internal properties of PropertyFieldDropdownInfoHeader custom field
+ */
+export interface IPropertyFieldDropdownInfoHeaderPropsInternal extends IPropertyPaneCustomFieldProps, IPropertyPaneDropdownProps, IPropertyFieldHeaderCalloutProps {
+}
+
+/**
+ * Public properties of PropertyFieldDropdownInfoHeader custom field
+ */
+export interface IPropertyFieldDropdownInfoHeaderProps extends IPropertyPaneDropdownProps, IPropertyFieldHeaderCalloutProps {
+    key: string;
+}

--- a/src/propertyFields/dropdownInfoHeader/IPropertyFieldDropdownInfoHeaderHost.ts
+++ b/src/propertyFields/dropdownInfoHeader/IPropertyFieldDropdownInfoHeaderHost.ts
@@ -1,0 +1,9 @@
+import { IDropdownProps } from 'office-ui-fabric-react';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+/**
+ * PropertyFieldDropdownInfoHeaderHost properties interface
+ */
+export interface IPropertyFieldDropdownInfoHeaderHostProps extends IDropdownProps, IPropertyFieldHeaderCalloutProps {
+}

--- a/src/propertyFields/dropdownInfoHeader/PropertyFieldDropdownInfoHeader.ts
+++ b/src/propertyFields/dropdownInfoHeader/PropertyFieldDropdownInfoHeader.ts
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+    IPropertyPaneField,
+    PropertyPaneFieldType,
+    IPropertyPaneDropdownOption
+} from '@microsoft/sp-webpart-base';
+
+import PropertyFieldDropdownHost from './PropertyFieldDropdownInfoHeaderHost';
+
+import { IPropertyFieldDropdownInfoHeaderPropsInternal, IPropertyFieldDropdownInfoHeaderProps } from './IPropertyFieldDropdownInfoHeader';
+
+class PropertyFieldDropdownInfoHeaderBuilder implements IPropertyPaneField<IPropertyFieldDropdownInfoHeaderPropsInternal> {
+    public targetProperty: string;
+    public type: PropertyPaneFieldType = PropertyPaneFieldType.Custom;
+    public properties: IPropertyFieldDropdownInfoHeaderPropsInternal;
+    
+
+    private _onChangeCallback: (targetProperty?: string, newValue?: any) => void;
+
+    public constructor(_targetProperty: string, _properties: IPropertyFieldDropdownInfoHeaderPropsInternal) {
+        this.targetProperty = _targetProperty;
+        this.properties = _properties;
+
+        this.properties.onRender = this._render.bind(this);
+        this.properties.onDispose = this._dispose.bind(this);
+    }
+
+    private _render(elem: HTMLElement, context?: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
+
+        const props: IPropertyFieldDropdownInfoHeaderProps = <IPropertyFieldDropdownInfoHeaderProps>this.properties;
+
+        const element = React.createElement(PropertyFieldDropdownHost, {
+            ...props,
+            onChanged: this._onChanged.bind(this)
+        });
+
+        ReactDOM.render(element, elem);
+
+        if (changeCallback) {
+            this._onChangeCallback = changeCallback;
+        }
+    }
+
+    private _dispose(elem: HTMLElement) {
+        ReactDOM.unmountComponentAtNode(elem);
+    }
+
+    private _onChanged(item: IPropertyPaneDropdownOption): void {
+        if (this._onChangeCallback) {
+            this._onChangeCallback(this.targetProperty, item.key);
+        }
+    }
+}
+
+export function PropertyFieldDropdownInfoHeader(targetProperty: string, properties: IPropertyFieldDropdownInfoHeaderProps): IPropertyPaneField<IPropertyFieldDropdownInfoHeaderPropsInternal> {
+    return new PropertyFieldDropdownInfoHeaderBuilder(targetProperty, {
+        ...properties,
+        onRender: null,
+        onDispose: null
+    });
+}

--- a/src/propertyFields/dropdownInfoHeader/PropertyFieldDropdownInfoHeaderHost.tsx
+++ b/src/propertyFields/dropdownInfoHeader/PropertyFieldDropdownInfoHeaderHost.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Dropdown, IDropdownProps } from 'office-ui-fabric-react';
+import * as _ from 'lodash';
+
+import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldHeader';
+
+import { IPropertyFieldDropdownInfoHeaderHostProps } from './IPropertyFieldDropdownInfoHeaderHost';
+
+export default class PropertyFieldToggleHost extends React.Component<IPropertyFieldDropdownInfoHeaderHostProps, null> {
+    public render(): JSX.Element {
+        return (
+            <div>
+                <PropertyFieldHeader {...this.props} />
+                <Dropdown {..._.omit(this.props, ['label'])} />
+            </div>
+        );
+    }
+}

--- a/src/propertyFields/dropdownInfoHeader/index.ts
+++ b/src/propertyFields/dropdownInfoHeader/index.ts
@@ -1,0 +1,4 @@
+export * from './IPropertyFieldDropdownInfoHeader';
+export * from './PropertyFieldDropdownInfoHeader';
+export * from './IPropertyFieldDropdownInfoHeaderHost';
+export * from './PropertyFieldDropdownInfoHeaderHost';

--- a/src/propertyFields/textInfoHeader/IPropertyFieldTextInfoHeader.ts
+++ b/src/propertyFields/textInfoHeader/IPropertyFieldTextInfoHeader.ts
@@ -1,0 +1,16 @@
+import {
+    IPropertyPaneCustomFieldProps,
+    IPropertyPaneTextFieldProps
+} from '@microsoft/sp-webpart-base';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+export interface IPropertyFieldTextInfoHeaderPropsInternal 
+    extends IPropertyPaneCustomFieldProps, IPropertyPaneTextFieldProps, IPropertyFieldHeaderCalloutProps {}
+
+/**
+ * Public properties of PropertyFieldTextInfoHeader custom field
+ */
+export interface IPropertyFieldTextInfoHeaderProps extends IPropertyPaneTextFieldProps, IPropertyFieldHeaderCalloutProps {
+    key: string;
+}

--- a/src/propertyFields/textInfoHeader/IPropertyFieldTextInfoHeaderHost.ts
+++ b/src/propertyFields/textInfoHeader/IPropertyFieldTextInfoHeaderHost.ts
@@ -1,0 +1,9 @@
+import { ITextFieldProps } from 'office-ui-fabric-react';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+/**
+ * PropertyFieldTextInfoHeaderHost properties interface
+ */
+export interface IPropertyFieldTextInfoHeaderHostProps extends ITextFieldProps, IPropertyFieldHeaderCalloutProps {
+}

--- a/src/propertyFields/textInfoHeader/PropertyFieldTextInfoHeader.ts
+++ b/src/propertyFields/textInfoHeader/PropertyFieldTextInfoHeader.ts
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+    IPropertyPaneField,
+    PropertyPaneFieldType,
+    IPropertyPaneCustomFieldProps,
+    IPropertyPaneTextFieldProps
+} from '@microsoft/sp-webpart-base';
+
+import PropertyFieldTextInfoHeaderHost from './PropertyFieldTextInfoHeaderHost';
+
+import { IPropertyFieldTextInfoHeaderPropsInternal, IPropertyFieldTextInfoHeaderProps } from './IPropertyFieldTextInfoHeader';
+
+
+class PropertyFieldTextInfoHeaderBuilder implements IPropertyPaneField<IPropertyFieldTextInfoHeaderPropsInternal> {
+    public targetProperty: string;
+    public type: PropertyPaneFieldType = PropertyPaneFieldType.Custom;
+    public properties: IPropertyFieldTextInfoHeaderPropsInternal;
+
+    private _onChangeCallback: (targetProperty?: string, newValue?: any) => void;
+
+    public constructor(_targetProperty: string, _properties: IPropertyFieldTextInfoHeaderPropsInternal) {
+        this.targetProperty = _targetProperty;
+        this.properties = _properties;
+
+        this.properties.onRender = this._render.bind(this);
+        this.properties.onDispose = this._dispose.bind(this);
+    }
+
+    private _render(elem: HTMLElement, context?: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
+
+        const props: IPropertyFieldTextInfoHeaderProps = <IPropertyFieldTextInfoHeaderPropsInternal>this.properties;
+
+        const element = React.createElement(PropertyFieldTextInfoHeaderHost, {
+            ...props, 
+            onChanged: this._onChanged.bind(this)
+        });
+
+        ReactDOM.render(element, elem);
+
+        if (changeCallback) {
+            this._onChangeCallback = changeCallback;
+        }
+    }
+
+    private _dispose(elem: HTMLElement) {
+        ReactDOM.unmountComponentAtNode(elem);
+    }
+
+    private _onChanged(checked: boolean): void {
+        if (this._onChangeCallback) {
+            this._onChangeCallback(this.targetProperty, checked);
+        }
+    }
+}
+
+export function PropertyFieldTextInfoHeader(targetProperty: string, properties: IPropertyFieldTextInfoHeaderProps): IPropertyPaneField<IPropertyFieldTextInfoHeaderPropsInternal> {
+    return new PropertyFieldTextInfoHeaderBuilder(targetProperty, {
+        ...properties,
+        onRender: null,
+        onDispose: null
+    });
+}

--- a/src/propertyFields/textInfoHeader/PropertyFieldTextInfoHeaderHost.tsx
+++ b/src/propertyFields/textInfoHeader/PropertyFieldTextInfoHeaderHost.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import * as _ from 'lodash';
+
+import { TextField } from 'office-ui-fabric-react';
+import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldHeader';
+
+import {IPropertyFieldTextInfoHeaderHostProps} from './IPropertyFieldTextInfoHeaderHost';
+
+export default class PropertyFieldTextInfoHeaderHost extends React.Component<IPropertyFieldTextInfoHeaderHostProps, null> {
+    public render(): JSX.Element {
+        return (
+            <div>
+                <PropertyFieldHeader {...this.props} />
+                <TextField { ..._.omit(this.props, ['label']) } />
+            </div>
+        );
+    }
+}

--- a/src/propertyFields/textInfoHeader/index.ts
+++ b/src/propertyFields/textInfoHeader/index.ts
@@ -1,0 +1,4 @@
+export * from './IPropertyFieldTextInfoHeader';
+export * from './PropertyFieldTextInfoHeader';
+export * from './IPropertyFieldTextInfoHeaderHost';
+export * from './PropertyFieldTextInfoHeaderHost';

--- a/src/propertyFields/toggleInfoHeader/IPropertyFieldToggleInfoHeader.ts
+++ b/src/propertyFields/toggleInfoHeader/IPropertyFieldToggleInfoHeader.ts
@@ -1,0 +1,18 @@
+import {
+    IPropertyPaneCustomFieldProps,
+    IPropertyPaneToggleProps
+} from '@microsoft/sp-webpart-base';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+export interface IPropertyFieldToggleInfoHeaderPropsInternal 
+    extends IPropertyPaneCustomFieldProps, IPropertyPaneToggleProps, IPropertyFieldHeaderCalloutProps {
+        key: string;
+    }
+
+/**
+ * Public properties of PropertyFieldToggleInfoHeader custom field
+ */
+export interface IPropertyFieldToggleInfoHeaderProps extends IPropertyPaneToggleProps, IPropertyFieldHeaderCalloutProps {
+    key: string;
+}

--- a/src/propertyFields/toggleInfoHeader/IPropertyFieldToggleInfoHeaderHost.ts
+++ b/src/propertyFields/toggleInfoHeader/IPropertyFieldToggleInfoHeaderHost.ts
@@ -1,0 +1,9 @@
+import { IToggleProps } from 'office-ui-fabric-react';
+
+import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
+
+/**
+ * PropertyFieldToggleInfoHeaderHost properties interface
+ */
+export interface IPropertyFieldToggleInfoHeaderHostProps extends IToggleProps, IPropertyFieldHeaderCalloutProps {
+}

--- a/src/propertyFields/toggleInfoHeader/PropertyFieldToggleInfoHeader.ts
+++ b/src/propertyFields/toggleInfoHeader/PropertyFieldToggleInfoHeader.ts
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+    IPropertyPaneField,
+    PropertyPaneFieldType
+} from '@microsoft/sp-webpart-base';
+
+import PropertyFieldToggleInfoHeaderHost from './PropertyFieldToggleInfoHeaderHost';
+
+import {IPropertyFieldToggleInfoHeaderPropsInternal, IPropertyFieldToggleInfoHeaderProps} from './IPropertyFieldToggleInfoHeader';
+
+class PropertyFieldToggleInfoHeaderBuilder implements IPropertyPaneField<IPropertyFieldToggleInfoHeaderPropsInternal> {
+    public targetProperty: string;
+    public type: PropertyPaneFieldType = PropertyPaneFieldType.Custom;
+    public properties: IPropertyFieldToggleInfoHeaderPropsInternal;
+
+    private _onChangeCallback: (targetProperty?: string, newValue?: any) => void;
+
+    public constructor(_targetProperty: string, _properties: IPropertyFieldToggleInfoHeaderPropsInternal) {
+        this.targetProperty = _targetProperty;
+        this.properties = _properties;
+
+        this.properties.onRender = this._render.bind(this);
+        this.properties.onDispose = this._dispose.bind(this);
+    }
+
+    private _render(elem: HTMLElement, context?: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
+
+        const props: IPropertyFieldToggleInfoHeaderProps = <IPropertyFieldToggleInfoHeaderProps>this.properties;
+
+        const element = React.createElement(PropertyFieldToggleInfoHeaderHost, {
+            ...props,
+            onChanged: this._onChanged.bind(this)
+        });
+
+        ReactDOM.render(element, elem);
+
+        if (changeCallback) {
+            this._onChangeCallback = changeCallback;
+        }
+    }
+
+    private _dispose(elem: HTMLElement) {
+        ReactDOM.unmountComponentAtNode(elem);
+    }
+
+    private _onChanged(checked: boolean): void {
+        if (this._onChangeCallback) {
+            this._onChangeCallback(this.targetProperty, checked);
+        }
+    }
+}
+
+export function PropertyFieldToggleInfoHeader(targetProperty: string, properties: IPropertyFieldToggleInfoHeaderProps): IPropertyPaneField<IPropertyFieldToggleInfoHeaderPropsInternal> {
+    return new PropertyFieldToggleInfoHeaderBuilder(targetProperty, {
+        ...properties,
+        onRender: null,
+        onDispose: null
+    });
+}

--- a/src/propertyFields/toggleInfoHeader/PropertyFieldToggleInfoHeaderHost.tsx
+++ b/src/propertyFields/toggleInfoHeader/PropertyFieldToggleInfoHeaderHost.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Toggle } from 'office-ui-fabric-react';
+
+import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldHeader';
+
+import { IPropertyFieldToggleInfoHeaderHostProps } from './IPropertyFieldToggleInfoHeaderHost';
+
+export default class PropertyFieldToggleInfoHeaderHost extends React.Component<IPropertyFieldToggleInfoHeaderHostProps, null> {
+    public render(): JSX.Element {
+        return (
+            <div>
+                <PropertyFieldHeader {...this.props} />
+                <Toggle {..._.omit(this.props, ['label'])} />
+            </div>
+        );
+    }
+}

--- a/src/propertyFields/toggleInfoHeader/index.ts
+++ b/src/propertyFields/toggleInfoHeader/index.ts
@@ -1,0 +1,4 @@
+export * from './IPropertyFieldToggleInfoHeader';
+export * from './PropertyFieldToggleInfoHeader';
+export * from './IPropertyFieldToggleInfoHeaderHost';
+export * from './PropertyFieldToggleInfoHeaderHost';

--- a/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
+++ b/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
@@ -12,4 +12,7 @@ export interface IPropertyControlsTestWebPartProps {
   fileUrl: string;
   color: string;
   spinValue: number;
+  dropdownInfoHeaderKey: string;
+  textInfoHeaderValue: string;
+  toggleInfoHeaderValue: boolean;
 }

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.manifest.json
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.manifest.json
@@ -26,7 +26,8 @@
     },
     "officeFabricIconFontName": "Settings",
     "properties": {
-      "description": "PropertyControlsTest"
+      "description": "PropertyControlsTest",
+      "dropdownInfoHeaderKey": "gryffindor"
     }
   }]
 }

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -11,12 +11,16 @@ import * as strings from 'PropertyControlsTestWebPartStrings';
 import PropertyControlsTest from './components/PropertyControlsTest';
 import { IPropertyControlsTestProps } from './components/IPropertyControlsTestProps';
 import { IPropertyControlsTestWebPartProps } from './IPropertyControlsTestWebPartProps';
+import { CalloutTriggers } from '../../PropertyFieldHeader';
 import { PropertyFieldPeoplePicker, PrincipalType } from '../../PropertyFieldPeoplePicker';
 import { PropertyFieldListPicker, PropertyFieldListPickerOrderBy } from '../../PropertyFieldListPicker';
 import { PropertyFieldTermPicker } from '../../PropertyFieldTermPicker';
 import { PropertyFieldDateTimePicker, DateConvention, TimeConvention } from '../../PropertyFieldDateTimePicker';
 import { PropertyFieldColorPicker, PropertyFieldColorPickerStyle } from '../../PropertyFieldColorPicker';
 import { PropertyFieldSpinButton } from '../../PropertyFieldSpinButton';
+import { PropertyFieldDropdownInfoHeader } from '../../PropertyFieldDropdownInfoHeader';
+import { PropertyFieldTextInfoHeader } from '../../PropertyFieldTextInfoHeader';
+import { PropertyFieldToggleInfoHeader } from '../../PropertyFieldToggleInfoHeader';
 
 /**
  * Web part that can be used to test out the various property controls
@@ -34,7 +38,10 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
         terms: this.properties.terms || [],
         datetime: this.properties.datetime || { value: null, displayValue: null },
         color: this.properties.color,
-        spinValue: this.properties.spinValue
+        spinValue: this.properties.spinValue,
+        dropdownInfoHeaderKey: this.properties.dropdownInfoHeaderKey,
+        textInfoHeaderValue: this.properties.textInfoHeaderValue,
+        toggleInfoHeaderValue: this.properties.toggleInfoHeaderValue
       }
     );
 
@@ -50,6 +57,11 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
   }
 
   protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+
+    const dropdownInfoHeaderSelectedKey: string = this.properties.dropdownInfoHeaderKey || 'gryffindor';
+    const dropdownInfoHeaderCallountContent: JSX.Element = this.getDropdownInfoHeaderCalloutContent();
+
+
     return {
       pages: [
         {
@@ -156,6 +168,43 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   //incrementIconName: 'CalculatorAddition',
                   //decrementIconName: 'CalculatorSubtract',
                   key: 'spinButtonFieldId'
+                }),
+                PropertyFieldDropdownInfoHeader('dropdownInfoHeaderKey', {
+                  calloutTrigger: CalloutTriggers.Hover,
+                  key: 'dropdownInfoHeaderFieldId',
+                  label: 'Select your house',
+                  options: [{
+                    key: 'gryffindor',
+                    text: 'Gryffindor'
+                  }, {
+                    key: 'hufflepuff',
+                    text: 'Hufflepuff'
+                  }, {
+                    key: 'ravenclaw',
+                    text: 'Ravenclaw'
+                  }, {
+                    key: 'slytherin',
+                    text: 'Slytherin'
+                  }],
+                  selectedKey: dropdownInfoHeaderSelectedKey,
+                  calloutContent: dropdownInfoHeaderCallountContent
+                }),
+                PropertyFieldTextInfoHeader('textInfoHeaderValue', {
+                  calloutTrigger: CalloutTriggers.Hover,
+                  key: 'textInfoHeaderFieldId',
+                  label: 'Describe your PnP passion with few words',
+                  calloutContent: React.createElement('span', {}, 'You can describe your passion with such words as strong, cosmic, all-absorbing, etc.'),
+                  calloutWidth: 150,
+                  value: this.properties.textInfoHeaderValue
+                }),
+                PropertyFieldToggleInfoHeader('toggleInfoHeaderValue', {
+                  calloutTrigger: CalloutTriggers.Click,
+                  key: 'toggleInfoHeaderFieldId',
+                  label: 'Select your super hero universe',
+                  calloutContent: React.createElement('p', {}, 'Select one of two universes of super heroes: DC comics with Superman, Batman, Wonder Woman, etc.; or Marvel with X-Men, Spider-Man, Avengers, etc.'),
+                  onText: 'Marvel',
+                  offText: 'DC Comics',
+                  checked: this.properties.toggleInfoHeaderValue
                 })
               ]
             }
@@ -163,5 +212,16 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
         }
       ]
     };
+  }
+
+  private getDropdownInfoHeaderCalloutContent(): JSX.Element {
+    const selectedKey: string = this.properties.dropdownInfoHeaderKey;
+
+    if (selectedKey) {
+      return React.createElement('div', {}, `you have selected ${selectedKey}`);
+    }
+    else {
+      return React.createElement('div', {}, `you haven't selecte any house`);
+    }
   }
 }

--- a/src/webparts/propertyControlsTest/components/IPropertyControlsTestProps.ts
+++ b/src/webparts/propertyControlsTest/components/IPropertyControlsTestProps.ts
@@ -13,4 +13,7 @@ export interface IPropertyControlsTestProps {
   datetime: IDateTimeFieldValue;
   color: string;
   spinValue: number;
+  dropdownInfoHeaderKey: string;
+  textInfoHeaderValue: string;
+  toggleInfoHeaderValue: boolean;
 }

--- a/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
+++ b/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
@@ -23,6 +23,9 @@ export default class PropertyControlsTest extends React.Component<IPropertyContr
               <p className="ms-font-m ms-fontColor-neutralDark">Date: {this.props.datetime.displayValue}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Color: <span className={styles.colorBox} style={{backgroundColor:this.props.color}}>&nbsp;</span>{this.props.color}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Spin Value: {this.props.spinValue}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark">Dropdown Info Header Key: {this.props.dropdownInfoHeaderKey}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark">Text Info Header Value: {this.props.textInfoHeaderValue}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark">Toggle Info Header Value: {this.props.toggleInfoHeaderValue ? 'Marvel' : 'DC Comics'}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
…down, toggle, text

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | no

#### What's in this Pull Request?

This pull request contains property pane fields that are based on standard ones (TextField, Dropdown and Toggle) but provide an info icon and callout when hovering or clicking on it.
Developer can select the event (Click or Hover) to display a callout and also some properties of the callout:
```
    /**
     * Callout content - any HTML
     */
    calloutContent?: React.ReactNode;
    /**
     * Custom width for callout including borders. If value is 0, no width is applied.
     */
    calloutWidth?: number;
    /**
     * Event to show the callout
     */
    calloutTrigger?: CalloutTriggers;
    /**
     * The gap between the Callout and the target
     */
    gapSpace?: number;
```

The example of the fields is shown in the screenshot below.
![info-header](https://user-images.githubusercontent.com/17036219/32592028-c86c003c-c4d6-11e7-8045-bc0683800557.png)

P.S.: I've started with dropdown, text and toggle. But if this kind of fields would be interesting I can work on other as well.