### PR TITLE
SPTermStorePickerService and IPropertyFieldTermPickerHostProps connection released

### DIFF
--- a/src/services/ISPTermStorePickerService.ts
+++ b/src/services/ISPTermStorePickerService.ts
@@ -70,3 +70,12 @@ export interface ITerm {
   TermSet: ITermSetMinimal;
   PathDepth?: number;
 }
+
+/**
+ * Properties for the Term Store Picker Service
+ */
+export interface ISPTermStorePickerServiceProps {
+  limitByGroupNameOrID?: string;
+  limitByTermsetNameOrID?: string;
+  excludeSystemGroup?: boolean;
+}

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -10,7 +10,7 @@ import { Environment, EnvironmentType } from '@microsoft/sp-core-library';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
 import { IPropertyFieldTermPickerHostProps } from './../propertyFields/termPicker/IPropertyFieldTermPickerHost';
 import { ISPTermStores, ISPTermStore, ISPTermGroups, ISPTermGroup, ICheckedTerms, ICheckedTerm } from './../propertyFields/termPicker/IPropertyFieldTermPicker';
-import { ITermStore, ITerms, ITerm, IGroup, ITermSet } from './ISPTermStorePickerService';
+import { ITermStore, ITerms, ITerm, IGroup, ITermSet, ISPTermStorePickerServiceProps } from './ISPTermStorePickerService';
 import SPTermStoreMockHttpClient from './SPTermStorePickerMockService';
 
 /**
@@ -24,7 +24,7 @@ export default class SPTermStorePickerService {
   /**
    * Service constructor
    */
-  constructor(private props: IPropertyFieldTermPickerHostProps, private context: IWebPartContext) {
+  constructor(private props: ISPTermStorePickerServiceProps, private context: IWebPartContext) {
     this.clientServiceUrl = this.context.pageContext.web.absoluteUrl + '/_vti_bin/client.svc/ProcessQuery';
   }
 


### PR DESCRIPTION
…tion released

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | no

#### What's in this Pull Request?

Currently `SPTermStorePickerService` constructor has a parameter of type `IPropertyFieldTermPickerHostProps`. But only 3 properties from `IPropertyFieldTermPickerHostProps` are actually in use. 
But if you want to use the service outside of TermStorePicker control, you'll need to provide fake values for a bunch of required properties from `IPropertyFieldTermPickerHostProps`.
So, I've added `ISPTermStorePickerServiceProps` interface to contain only props that are in use in the service.
