### PR TITLE
Add property for target site url when retrieving lists

### DIFF
--- a/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
@@ -22,6 +22,10 @@ export interface IPropertyFieldListPickerProps {
    */
   context: IWebPartContext;
   /**
+   * Relative Web Url of target site (user requires permissions)
+   */
+  webAbsoluteUrl?: string;
+  /**
    * Initial selected list set of the control
    */
   selectedList?: string | string[];
@@ -104,6 +108,7 @@ export interface IPropertyFieldListPickerPropsInternal extends IPropertyFieldLis
   label: string;
   targetProperty: string;
   context: IWebPartContext;
+  webAbsoluteUrl?: string;
   selectedList?: string;
   selectedLists?: string[];
   baseTemplate?: number;

--- a/src/propertyFields/listPicker/PropertyFieldListMultiPickerHost.tsx
+++ b/src/propertyFields/listPicker/PropertyFieldListMultiPickerHost.tsx
@@ -47,7 +47,7 @@ export default class PropertyFieldListMultiPickerHost extends React.Component<IP
   }
 
   /**
-  * Loads the list from SharePoint current web site
+  * Loads the list from SharePoint current web site, or target site if specified by webRelativeUrl
   */
   private loadLists(): void {
     // Builds the SharePoint List service

--- a/src/propertyFields/listPicker/PropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/PropertyFieldListPicker.ts
@@ -24,6 +24,7 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
   //Custom properties label: string;
   private label: string;
   private context: IWebPartContext;
+  private webAbsoluteUrl?: string;
   private selectedList: string;
   private selectedLists: string[];
   private baseTemplate: number;
@@ -54,6 +55,7 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
     this.properties.onRender = this.render;
     this.label = _properties.label;
     this.context = _properties.context;
+    this.webAbsoluteUrl = _properties.webAbsoluteUrl;
     this.selectedList = _properties.selectedList;
     this.selectedLists = _properties.selectedLists;
     this.baseTemplate = _properties.baseTemplate;
@@ -84,6 +86,7 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
       label: this.label,
       targetProperty: this.targetProperty,
       context: this.context,
+      webAbsoluteUrl: this.webAbsoluteUrl,
       baseTemplate: this.baseTemplate,
       orderBy: this.orderBy,
       multiSelect: this.multiSelect,
@@ -139,6 +142,7 @@ export function PropertyFieldListPicker(targetProperty: string, properties: IPro
     label: properties.label,
     targetProperty: targetProperty,
     context: properties.context,
+    webAbsoluteUrl: properties.webAbsoluteUrl,
     selectedList: typeof properties.selectedList === 'string' ? properties.selectedList : null,
     selectedLists: typeof properties.selectedList !== 'string' ? properties.selectedList : null,
     baseTemplate: properties.baseTemplate,

--- a/src/propertyFields/listPicker/PropertyFieldListPickerHost.tsx
+++ b/src/propertyFields/listPicker/PropertyFieldListPickerHost.tsx
@@ -49,7 +49,7 @@ export default class PropertyFieldListPickerHost extends React.Component<IProper
   }
 
   /**
-   * Loads the list from SharePoint current web site
+   * Loads the list from SharePoint current web site, or target site if specified by webRelativeUrl
    */
   private loadLists(): void {
     const listService: SPListPickerService = new SPListPickerService(this.props, this.props.context);

--- a/src/services/SPListPickerService.ts
+++ b/src/services/SPListPickerService.ts
@@ -23,7 +23,7 @@ export default class SPListPickerService {
   }
 
   /**
-   * Gets the collection of libs in the current SharePoint site
+   * Gets the collection of libs in the current SharePoint site, or target site if specified by webRelativeUrl
    */
   public getLibs(): Promise<ISPLists> {
     if (Environment.type === EnvironmentType.Local) {
@@ -31,8 +31,10 @@ export default class SPListPickerService {
       return this.getLibsFromMock();
     }
     else {
+      // use the web relative url if provided, otherwise default to current SharePoint site
+      const webAbsoluteUrl = this.props.webAbsoluteUrl ? this.props.webAbsoluteUrl : this.context.pageContext.web.absoluteUrl;
       // If the running environment is SharePoint, request the lists REST service
-      let queryUrl: string = `${this.context.pageContext.web.absoluteUrl}/_api/lists?$select=Title,id,BaseTemplate`;
+      let queryUrl: string = `${webAbsoluteUrl}/_api/lists?$select=Title,id,BaseTemplate`;
       // Check if the orderBy property is provided
       if (this.props.orderBy !== null) {
         queryUrl += '&$orderby=';

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -250,7 +250,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   context: this.context,
                   onGetErrorMessage: null,
                   deferredValidationTime: 0,
-                  key: 'listPickerFieldId'
+                  key: 'listPickerFieldId',
+                  webAbsoluteUrl: this.context.pageContext.web.absoluteUrl
                 }),
                 PropertyFieldListPicker('multiList', {
                   label: 'Select multiple lists',
@@ -268,7 +269,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   context: this.context,
                   onGetErrorMessage: null,
                   deferredValidationTime: 0,
-                  key: 'multiListPickerFieldId'
+                  key: 'multiListPickerFieldId',
+                  webAbsoluteUrl: this.context.pageContext.web.absoluteUrl
                 }),
                 PropertyFieldDateTimePicker('datetime', {
                   label: 'Select the date and time',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #21  

#### What's in this Pull Request?

Adds a new property to the list picker controls to allow the target web to be specified.

