### PR TITLE
Merge for 1.9.0 release

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -11,7 +11,8 @@
           "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"
         ],
         "fixes": [
-          "`PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)"
+          "`PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)",
+          "`PropertyFieldOrder`: fixed an issue where items where provided async [#81](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/81)"
         ]
       },
       "contributions": []

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -5,6 +5,7 @@
       "changes": {
         "new": [],
         "enhancements": [
+          "`PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)",
           "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"
         ],
         "fixes": []

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -10,7 +10,9 @@
           "`PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)",
           "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"
         ],
-        "fixes": []
+        "fixes": [
+          "`PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)"
+        ]
       },
       "contributions": []
     },

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -5,6 +5,7 @@
       "changes": {
         "new": [],
         "enhancements": [
+          "`PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)",
           "`PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)",
           "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"
         ],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,17 @@
 {
   "versions": [
     {
+      "version": "1.9.0",
+      "changes": {
+        "new": [],
+        "enhancements": [
+          "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"
+        ],
+        "fixes": []
+      },
+      "contributions": []
+    },
+    {
       "version": "1.8.0",
       "changes": {
         "new": [],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -5,6 +5,7 @@
       "changes": {
         "new": [],
         "enhancements": [
+          "`PropertyFieldCollectionData`: Added custom validation for `string`, `number`, `icon`, and `URL` field types [#74](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/74)",
           "`PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)",
           "`PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)",
           "`PropertyFieldCollectionData`: Hide save button when \"Add and save\" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Fixes**
 
 - `PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)
+- `PropertyFieldOrder`: fixed an issue where items where provided async [#81](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/81)
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Enhancements**
 
-- PropertyFieldCollectionData: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
+- `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
+- `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 
+**Fixes**
+
+- `PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)
+
 ## 1.8.0
 
 **Enhancements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.9.0
+
+**Enhancements**
+
+- PropertyFieldCollectionData: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
+
 ## 1.8.0
 
 **Enhancements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCollectionData`: Added custom validation for `string`, `number`, `icon`, and `URL` field types [#74](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/74)
 - `PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -12,6 +12,7 @@
 **Fixes**
 
 - `PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)
+- `PropertyFieldOrder`: fixed an issue where items where provided async [#81](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/81)
 
 ## 1.8.0
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,7 +4,8 @@
 
 **Enhancements**
 
-- PropertyFieldCollectionData: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
+- `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
+- `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 
 ## 1.8.0
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -9,6 +9,10 @@
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 
+**Fixes**
+
+- `PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)
+
 ## 1.8.0
 
 **Enhancements**

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.9.0
+
+**Enhancements**
+
+- PropertyFieldCollectionData: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)
+
 ## 1.8.0
 
 **Enhancements**

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCollectionData`: Added custom validation for `string`, `number`, `icon`, and `URL` field types [#74](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/74)
 - `PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)
 - `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
 - `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)

--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -112,9 +112,10 @@ Interface `ICustomCollectionField`
 | ---- | ---- | ---- | ---- |
 | id | string | yes | ID of the field. |
 | title | string | yes | Title of the field. This will be used for the label in the table. |
-| type | yes | CustomCollectionFieldType | Specifies the type of field to render. |
-| required | no | boolean | Specify if the field is required. |
-| options | no | [IDropdownOption[]](https://developer.microsoft.com/en-us/fabric#/components/dropdown) | Dropdown options. Only necessary when dropdown type is used. |
+| type | CustomCollectionFieldType | yes | Specifies the type of field to render. |
+| required | boolean | no | Specify if the field is required. |
+| options | [IDropdownOption[]](https://developer.microsoft.com/en-us/fabric#/components/dropdown) | no | Dropdown options. Only necessary when dropdown type is used. |
+| placeholder | string | no | Placehoder text which will be used for the input field. If not provided the input title will be used. |
 
 Enum `CustomCollectionFieldType`
 

--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -117,6 +117,7 @@ Interface `ICustomCollectionField`
 | options | [IDropdownOption[]](https://developer.microsoft.com/en-us/fabric#/components/dropdown) | no | Dropdown options. Only necessary when dropdown type is used. |
 | placeholder | string | no | Placehoder text which will be used for the input field. If not provided the input title will be used. |
 | defaultValue | any | no | Specify a default value for the input field. |
+| onGetErrorMessage | (value: any): string \| Promise<string> | no | The method is used to get the validation error message and determine whether the input value is valid or not. |
 
 Enum `CustomCollectionFieldType`
 

--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -116,6 +116,7 @@ Interface `ICustomCollectionField`
 | required | boolean | no | Specify if the field is required. |
 | options | [IDropdownOption[]](https://developer.microsoft.com/en-us/fabric#/components/dropdown) | no | Dropdown options. Only necessary when dropdown type is used. |
 | placeholder | string | no | Placehoder text which will be used for the input field. If not provided the input title will be used. |
+| defaultValue | any | no | Specify a default value for the input field. |
 
 Enum `CustomCollectionFieldType`
 

--- a/docs/documentation/docs/controls/PropertyFieldListPicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldListPicker.md
@@ -65,6 +65,7 @@ The `PropertyFieldListPicker` control can be configured with the following prope
 | showSelectAll | boolean | no | Specify if you want the Select All checkbox. By default this is set to `false` (mult-list picker only). |
 | selectAllInList | boolean | no | Specify where to show the Select All checkbox. When false (default), checkbox is shown before the label, when true it is shown with the lists  (mult-list picker only). |
 | selectAllInListLabel | string | no | The label to use for the in list select all checkbox (mult-list picker only). |
+| webAbsoluteUrl | string | no | Absolute Web Url of target site (user requires permissions) |
 | onPropertyChange | function | yes | Defines a onPropertyChange function to raise when the date gets changed. |
 | properties | any | yes | Parent web part properties, this object is use to update the property value.  |
 | key | string | yes | An unique key that indicates the identity of this control. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/spfx-property-controls",
   "description": "Reusable property pane controls for SharePoint Framework solutions",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "1.8.0";
+export const version: string = "1.9.0";

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -1,5 +1,6 @@
 define([], function () {
   return {
+    propertyFieldMultiSelectNoOptions: "No options to select",
     InvalidUrlError: "The provided URL is not valid",
     // Common field labels
     'SaveButtonLabel': 'Save',

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -1,4 +1,5 @@
 declare interface IPropertyControlStrings {
+  propertyFieldMultiSelectNoOptions: string;
   InvalidUrlError: string;
   // PeoplePicker labels
   PeoplePickerSuggestedContacts: string;

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -29,6 +29,14 @@ export interface ICustomCollectionField {
    * Default value for the field
    */
   defaultValue?: any;
+  /**
+   * The method is used to get the validation error message and determine whether the input value is valid or not.
+   *
+   * When it returns string:
+   * - If valid, it returns empty string.
+   * - If invalid, the field will show a red border
+   */
+  onGetErrorMessage?: (value: any) => string | Promise<string>;
 }
 
 export enum CustomCollectionFieldType {

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -21,6 +21,10 @@ export interface ICustomCollectionField {
    * Dropdown options. Only nescessary when dropdown type is used.
    */
   options?: IDropdownOption[];
+  /**
+   * Input placeholder text.
+   */
+  placeholder?: string;
 }
 
 export enum CustomCollectionFieldType {

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -25,6 +25,10 @@ export interface ICustomCollectionField {
    * Input placeholder text.
    */
   placeholder?: string;
+  /**
+   * Default value for the field
+   */
+  defaultValue?: any;
 }
 
 export enum CustomCollectionFieldType {

--- a/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.module.scss
+++ b/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.module.scss
@@ -70,6 +70,10 @@
     text-overflow: ellipsis;
     outline: 0;
   }
+
+  &.invalidField {
+    border-color: #a80000;
+  }
 }
 
 .iconField {
@@ -84,7 +88,7 @@
   }
 }
 
-.urlField {
+.collectionDataField {
   > span {
     display: none;
   }

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -21,7 +21,8 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
     // Create an empty item with all properties
     this.emptyItem = {};
     for (const field of this.props.fields) {
-      this.emptyItem[field.id] = null;
+      // Assign default value or null to the emptyItem
+      this.emptyItem[field.id] = field.defaultValue || null;
     }
 
     this.state = {

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -182,7 +182,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
         return <Checkbox checked={item[field.id] ? item[field.id] : false}
                          onChange={(ev, value) => this.onValueChanged(field.id, value)} />;
       case CustomCollectionFieldType.dropdown:
-        return <Dropdown placeHolder={field.title}
+        return <Dropdown placeHolder={field.placeholder || field.title}
                          options={field.options}
                          selectedKey={item[field.id] || null}
                          required={field.required}
@@ -192,7 +192,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
           <div className={styles.numberField}>
             <input type="number"
                    role="spinbutton"
-                   placeholder={field.title}
+                   placeholder={field.placeholder || field.title}
                    aria-valuemax="99999"
                    aria-valuemin="-999999"
                    aria-valuenow={item[field.id] || ''}
@@ -205,7 +205,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
           <CollectionIconField field={field} item={item} fOnValueChange={this.onValueChanged} />
         );
       case CustomCollectionFieldType.url:
-        return <TextField placeholder={field.title}
+        return <TextField placeholder={field.placeholder || field.title}
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
                           className={styles.urlField}
@@ -222,7 +222,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                           }} />;
       case CustomCollectionFieldType.string:
       default:
-        return <TextField placeholder={field.title}
+        return <TextField placeholder={field.placeholder || field.title}
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
                           onChanged={(value) => this.onValueChanged(field.id, value)} />;

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -10,6 +10,7 @@ import { ICustomCollectionField, CustomCollectionFieldType, FieldValidator } fro
 import { Dropdown } from 'office-ui-fabric-react';
 import { CollectionIconField } from '../collectionIconField';
 import { clone } from '@microsoft/sp-lodash-subset';
+import { CollectionNumberField } from '../collectionNumberField';
 
 export class CollectionDataItem extends React.Component<ICollectionDataItemProps, ICollectionDataItemState> {
   private emptyItem: any = null;
@@ -173,7 +174,26 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
   }
 
   /**
+   * Allow custom field validation
+   *
+   * @param field
+   * @param value
+   */
+  private fieldValidation = async (field: ICustomCollectionField, value: any): Promise<string> => {
+    let validation = "";
+    if (field.onGetErrorMessage) {
+      validation = await field.onGetErrorMessage(value);
+    }
+    // Store the field validation
+    this.validation[field.id] = validation === "";
+    // Trigger field change
+    this.onValueChanged(field.id, value);
+    return validation;
+  }
+
+  /**
    * Render the field
+   *
    * @param field
    * @param item
    */
@@ -190,43 +210,48 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                          onChanged={(opt) => this.onValueChanged(field.id, opt.key)} />;
       case CustomCollectionFieldType.number:
         return (
-          <div className={styles.numberField}>
-            <input type="number"
-                   role="spinbutton"
-                   placeholder={field.placeholder || field.title}
-                   aria-valuemax="99999"
-                   aria-valuemin="-999999"
-                   aria-valuenow={item[field.id] || ''}
-                   value={item[field.id] || ''}
-                   onChange={(ev) => this.onValueChanged(field.id, ev.target.value)} />
-          </div>
+          <CollectionNumberField field={field} item={item} fOnValueChange={this.onValueChanged} fValidation={this.fieldValidation} />
         );
       case CustomCollectionFieldType.fabricIcon:
         return (
-          <CollectionIconField field={field} item={item} fOnValueChange={this.onValueChanged} />
+          <CollectionIconField field={field} item={item} fOnValueChange={this.onValueChanged} fValidation={this.fieldValidation} />
         );
       case CustomCollectionFieldType.url:
         return <TextField placeholder={field.placeholder || field.title}
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
-                          className={styles.urlField}
-                          onGetErrorMessage={(value) => {
-                            // Check if entered value is a valid URL
-                            const regEx: RegExp = /^((http|https)?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/;
-                            const isValid = (value === null || value.length === 0 || regEx.test(value));
+                          className={styles.collectionDataField}
+                          onGetErrorMessage={async (value) => {
+                            let isValid = true;
+                            let validation = "";
+
+                            // Check if custom validation is configured
+                            if (field.onGetErrorMessage) {
+                              // Using the custom validation
+                              validation = await field.onGetErrorMessage(value);
+                              isValid = validation === "";
+                            } else {
+                              // Check if entered value is a valid URL
+                              const regEx: RegExp = /^((http|https)?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/;
+                              isValid = (value === null || value.length === 0 || regEx.test(value));
+                              validation = isValid ? "" : strings.InvalidUrlError;
+                            }
+
                             // Store the field validation
                             this.validation[field.id] = isValid;
                             // Trigger field change
                             this.onValueChanged(field.id, value);
                             // Return the error message if needed
-                            return isValid ? "" : strings.InvalidUrlError;
+                            return validation;
                           }} />;
       case CustomCollectionFieldType.string:
       default:
         return <TextField placeholder={field.placeholder || field.title}
+                          className={styles.collectionDataField}
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
-                          onChanged={(value) => this.onValueChanged(field.id, value)} />;
+                          onChanged={(value) => this.onValueChanged(field.id, value)}
+                          onGetErrorMessage={(value: string) => this.fieldValidation(field, value)} />;
     }
   }
 

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -168,7 +168,7 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
 
         <div className={styles.panelActions}>
           { this.state.inCreationItem && <PrimaryButton text={strings.CollectionSaveAndAddButtonLabel} onClick={this.addAndSave} disabled={!this.allItemsValid()} /> }
-          <PrimaryButton text={strings.SaveButtonLabel} onClick={this.onSave} disabled={!this.allItemsValid()} />
+          { !this.state.inCreationItem && <PrimaryButton text={strings.SaveButtonLabel} onClick={this.onSave} disabled={!this.allItemsValid()} /> }
           <DefaultButton text={strings.CancelButtonLabel} onClick={this.onCancel} />
         </div>
       </div>

--- a/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
+++ b/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
@@ -16,7 +16,7 @@ export class CollectionIconField extends React.Component<ICollectionIconFieldPro
   public render(): React.ReactElement<ICollectionIconFieldProps> {
     return (
       <div className={styles.iconField}>
-        <TextField placeholder={this.props.field.title}
+        <TextField placeholder={this.props.field.placeholder || this.props.field.title}
                    value={this.props.item[this.props.field.id] ? this.props.item[this.props.field.id] : ""}
                    required={this.props.field.required}
                    onChanged={(value) => this.props.fOnValueChange(this.props.field.id, value)} />

--- a/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
+++ b/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
@@ -5,21 +5,16 @@ import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
 import { Icon } from 'office-ui-fabric-react/lib/components/Icon';
 
 export class CollectionIconField extends React.Component<ICollectionIconFieldProps, {}> {
-  constructor(props: ICollectionIconFieldProps) {
-    super(props);
-
-    this.state = {
-      iconName: null
-    };
-  }
 
   public render(): React.ReactElement<ICollectionIconFieldProps> {
     return (
       <div className={styles.iconField}>
         <TextField placeholder={this.props.field.placeholder || this.props.field.title}
+                   className={styles.collectionDataField}
                    value={this.props.item[this.props.field.id] ? this.props.item[this.props.field.id] : ""}
                    required={this.props.field.required}
-                   onChanged={(value) => this.props.fOnValueChange(this.props.field.id, value)} />
+                   onChanged={(value) => this.props.fOnValueChange(this.props.field.id, value)}
+                   onGetErrorMessage={(value) => this.props.fValidation(this.props.field, value)} />
         <Icon iconName={this.props.item[this.props.field.id] ? this.props.item[this.props.field.id] : ""} />
       </div>
     );

--- a/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
+++ b/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import styles from '../PropertyFieldCollectionDataHost.module.scss';
+import { ICollectionNumberFieldProps, ICollectionNumberFieldState } from '.';
+import { ICustomCollectionField } from '..';
+
+export class CollectionNumberField extends React.Component<ICollectionNumberFieldProps, ICollectionNumberFieldState> {
+  constructor(props: ICollectionNumberFieldProps) {
+    super(props);
+
+    this.state = {
+      errorMessage: ''
+    };
+  }
+
+  /**
+   * componentWillMount lifecycle hook
+   */
+  public componentWillMount(): void {
+    this.valueChange(this.props.field, this.props.item[this.props.field.id]);
+  }
+
+  /**
+   * Value change event handler
+   *
+   * @param field
+   * @param value
+   */
+  private valueChange = async (field: ICustomCollectionField, value: string | number) => {
+    const inputVal = typeof value === "string" ? parseInt(value) : value;
+    const validation = await this.props.fValidation(field, inputVal);
+    // Update the error message
+    this.setState({
+      errorMessage: validation
+    });
+  }
+
+  /**
+   * Default React render method
+   */
+  public render(): React.ReactElement<ICollectionNumberFieldProps> {
+    return (
+      <div className={`${styles.numberField} ${this.state.errorMessage ? styles.invalidField : ""}`}>
+        <input type="number"
+               role="spinbutton"
+               placeholder={this.props.field.placeholder || this.props.field.title}
+               aria-valuemax="99999"
+               aria-valuemin="-999999"
+               aria-valuenow={this.props.item[this.props.field.id] || ''}
+               aria-invalid={!!this.state.errorMessage}
+               value={this.props.item[this.props.field.id] || ''}
+               onChange={(ev) => this.valueChange(this.props.field, ev.target.value)} />
+      </div>
+    );
+  }
+}

--- a/src/propertyFields/collectionData/collectionNumberField/ICollectionNumberFieldProps.ts
+++ b/src/propertyFields/collectionData/collectionNumberField/ICollectionNumberFieldProps.ts
@@ -1,6 +1,6 @@
 import { ICustomCollectionField } from "..";
 
-export interface ICollectionIconFieldProps {
+export interface ICollectionNumberFieldProps {
   field: ICustomCollectionField;
   item: any;
 

--- a/src/propertyFields/collectionData/collectionNumberField/ICollectionNumberFieldState.ts
+++ b/src/propertyFields/collectionData/collectionNumberField/ICollectionNumberFieldState.ts
@@ -1,0 +1,3 @@
+export interface ICollectionNumberFieldState {
+  errorMessage: string;
+}

--- a/src/propertyFields/collectionData/collectionNumberField/index.ts
+++ b/src/propertyFields/collectionData/collectionNumberField/index.ts
@@ -1,0 +1,3 @@
+export * from './CollectionNumberField';
+export * from './ICollectionNumberFieldProps';
+export * from './ICollectionNumberFieldState';

--- a/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
@@ -22,7 +22,7 @@ export interface IPropertyFieldListPickerProps {
    */
   context: IWebPartContext;
   /**
-   * Relative Web Url of target site (user requires permissions)
+   * Absolute Web Url of target site (user requires permissions)
    */
   webAbsoluteUrl?: string;
   /**

--- a/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
+++ b/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
@@ -1,9 +1,11 @@
+import * as strings from 'PropertyControlStrings';
 import * as React from 'react';
 import { Dropdown } from 'office-ui-fabric-react/lib/components/Dropdown';
+import { Label } from 'office-ui-fabric-react/lib/components/Label';
 import { IPropertyFieldMultiSelectHostProps } from './IPropertyFieldMultiSelectHost';
 import * as telemetry from '../../common/telemetry';
 
-export default class PropertyFieldMultiSelectHost extends React.Component<IPropertyFieldMultiSelectHostProps, null> {
+export default class PropertyFieldMultiSelectHost extends React.Component<IPropertyFieldMultiSelectHostProps, {}> {
   constructor(props: IPropertyFieldMultiSelectHostProps) {
     super(props);
 
@@ -13,9 +15,18 @@ export default class PropertyFieldMultiSelectHost extends React.Component<IPrope
   }
 
   public render(): JSX.Element {
+    if (this.props.options && this.props.options.length === 0 &&
+        this.props.selectedKeys && this.props.selectedKeys.length > 0) {
+      return (
+        <div>
+          <Dropdown label={this.props.label} placeHolder={strings.propertyFieldMultiSelectNoOptions} disabled={true} />
+        </div>
+      );
+    }
+
     return (
       <div>
-        <Dropdown {...this.props} multiSelect={true} />
+        <Dropdown key={`MultiSelectOptions-${this.props.options.length}`} {...this.props} multiSelect={true} />
       </div>
     );
   }

--- a/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
+++ b/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
@@ -15,18 +15,17 @@ export default class PropertyFieldMultiSelectHost extends React.Component<IPrope
   }
 
   public render(): JSX.Element {
-    if (this.props.options && this.props.options.length === 0 &&
-        this.props.selectedKeys && this.props.selectedKeys.length > 0) {
+    if (!this.props.options || (this.props.options && this.props.options.length === 0)) {
       return (
         <div>
-          <Dropdown label={this.props.label} placeHolder={strings.propertyFieldMultiSelectNoOptions} disabled={true} />
+          <Dropdown key={`MultiSelectOptionsDisabled`} label={this.props.label} options={[]} placeHolder={strings.propertyFieldMultiSelectNoOptions} disabled={true} />
         </div>
       );
     }
 
     return (
       <div>
-        <Dropdown key={`MultiSelectOptions-${this.props.options.length}`} {...this.props} multiSelect={true} />
+        <Dropdown key={`MultiSelectOptions`} {...this.props} multiSelect={true} />
       </div>
     );
   }

--- a/src/propertyFields/order/PropertyFieldOrderHost.module.scss
+++ b/src/propertyFields/order/PropertyFieldOrderHost.module.scss
@@ -6,7 +6,7 @@ $ms-color-white: '[theme:white, default:#ffffff]';
 
 
 .propertyFieldOrder {
-  margin-bottom: -8px;
+  margin-bottom: 2px;
 
   ul {
     padding: 0.5px;
@@ -19,7 +19,7 @@ $ms-color-white: '[theme:white, default:#ffffff]';
     li {
       color: $ms-color-neutralTertiary;
     }
-    
+
   }
 
   li {
@@ -29,7 +29,7 @@ $ms-color-white: '[theme:white, default:#ffffff]';
     border-color: $ms-color-neutralLight;
     outline: 0.5px solid;
     outline-color: $ms-color-neutralLight;
-  
+
     .enabled & :hover {
       background-color: $ms-color-neutralLighter;
     }

--- a/src/propertyFields/order/PropertyFieldOrderHost.tsx
+++ b/src/propertyFields/order/PropertyFieldOrderHost.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import * as telemetry from '../../common/telemetry';
 import { IPropertyFieldOrderHostProps, IPropertyFieldOrderHostState } from './IPropertyFieldOrderHost';
 import styles from './PropertyFieldOrderHost.module.scss';
+import { isEqual } from '@microsoft/sp-lodash-subset';
 
 export default class PropertyFieldOrderHost extends React.Component<IPropertyFieldOrderHostProps, IPropertyFieldOrderHostState> {
 
@@ -38,27 +39,31 @@ export default class PropertyFieldOrderHost extends React.Component<IPropertyFie
 		this._draggedItem = null;
 
 		this.state = {
-			items: this.props.items
+			items: []
 		};
-	}
+  }
 
 	public render(): JSX.Element {
 		return (
 			<div className={styles.propertyFieldOrder}>
 				{this.props.label && <Label>{this.props.label}</Label>}
 				<ul style={{maxHeight: this.props.maxHeight ? this.props.maxHeight + 'px' : '100%'}} className={!this.props.disabled ? styles.enabled : styles.disabled}>
-					{this.state.items.map((value:any, index:number) => {
-						return (
-							<li
-								ref={this.registerRef}
-								key={index}
-								draggable={!this.props.disableDragAndDrop && !this.props.disabled}
-								style={{cursor: !this.props.disableDragAndDrop && !this.props.disabled ? 'pointer' : 'default'}}
-							>{this.renderItem(value,index)}</li>
-						);
-					})}
-					{this.state.items.length &&
-						<div className={styles.lastBox} ref={(ref:HTMLElement) => {this._lastBox = ref;}}/>
+          {
+            (this.state.items && this.state.items.length >= 0) && (
+              this.state.items.map((value:any, index:number) => {
+                return (
+                  <li
+                    ref={this.registerRef}
+                    key={index}
+                    draggable={!this.props.disableDragAndDrop && !this.props.disabled}
+                    style={{cursor: !this.props.disableDragAndDrop && !this.props.disabled ? 'pointer' : 'default'}}
+                  >{this.renderItem(value,index)}</li>
+                );
+              })
+            )
+          }
+					{
+            (this.state.items && this.state.items.length) && <div className={styles.lastBox} ref={(ref:HTMLElement) => {this._lastBox = ref;}}/>
 					}
 				</ul>
 			</div>
@@ -119,16 +124,31 @@ export default class PropertyFieldOrderHost extends React.Component<IPropertyFie
 				/>
 			</div>
 		);
-	}
+  }
+
+  public componentWillMount(): void {
+    this.setState({
+      items: this.props.items || []
+    });
+  }
 
 	public componentDidMount(): void {
 		this.setupSubscriptions();
 	}
 
+  public componentWillUpdate(nextProps: IPropertyFieldOrderHostProps): void {
+    // Check if the provided items are still the same
+    if (!isEqual(nextProps.items, this.state.items)) {
+      this.setState({
+        items: this.props.items || []
+      });
+    }
+  }
+
 	public componentDidUpdate(): void {
 		this.cleanupSubscriptions();
 		this.setupSubscriptions();
-	}
+  }
 
 	public componentWillUnmount(): void {
 		this.cleanupSubscriptions();

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -238,6 +238,13 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   options: this.multiSelectProps,
                   selectedKeys: this.properties.multiSelect
                 }),
+                PropertyFieldOrder("asyncOrderItems", {
+                  key: "asyncOrderItems",
+                  label: "Async order items",
+                  items: this.properties.multiSelect,
+                  properties: this.properties,
+                  onPropertyChange: this.onPropertyPaneFieldChanged
+                }),
                 PropertyFieldCodeEditor('htmlCode', {
                   label: 'Edit HTML Code',
                   panelTitle: 'Edit HTML Code',

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -81,6 +81,15 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
     return true;
   }
 
+  private minLengthValidation (value: string) {
+    return value.length >= 3 ? "" : "Should at least contain 3 characters.";
+  }
+
+  private ageValidation (value: number) {
+    console.log(value);
+    return value >= 18 ? "" : "Person should be at least 18 years old";
+  }
+
   protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
 
     const dropdownWithCalloutSelectedKey: string = this.properties.dropdownWithCalloutKey || 'gryffindor';
@@ -109,7 +118,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       title: "Firstname",
                       type: CustomCollectionFieldType.string,
                       required: true,
-                      placeholder: "Enter the firstname"
+                      placeholder: "Enter the firstname",
+                      onGetErrorMessage: this.minLengthValidation
                     },
                     {
                       id: "Lastname",
@@ -121,7 +131,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       title: "Age",
                       type: CustomCollectionFieldType.number,
                       required: true,
-                      placeholder: "Enter the age"
+                      placeholder: "Enter the age",
+                      onGetErrorMessage: this.ageValidation
                     },
                     {
                       id: "City",
@@ -156,7 +167,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       title: "Icon Name",
                       type: CustomCollectionFieldType.fabricIcon,
                       placeholder: "Enter the name of the icon",
-                      defaultValue: "website"
+                      defaultValue: "website",
+                      onGetErrorMessage: this.minLengthValidation
                     },
                     {
                       id: "URL",

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -40,6 +40,7 @@ import { PropertyFieldSwatchColorPicker, PropertyFieldSwatchColorPickerStyle } f
  * Web part that can be used to test out the various property controls
  */
 export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<IPropertyControlsTestWebPartProps> {
+  private multiSelectProps = [];
 
   public render(): void {
     const element: React.ReactElement<IPropertyControlsTestProps> = React.createElement(
@@ -88,6 +89,26 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
   private ageValidation (value: number) {
     console.log(value);
     return value >= 18 ? "" : "Person should be at least 18 years old";
+  }
+
+  protected onPropertyPaneConfigurationStart(): void {
+    setTimeout(() => {
+      this.multiSelectProps = [
+        {
+          key: "EN",
+          text: "EN"
+        },
+        {
+          key: "FR",
+          text: "FR"
+        },
+        {
+          key: "NL",
+          text: "NL"
+        }
+      ];
+      this.context.propertyPane.refresh();
+    }, 2000);
   }
 
   protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
@@ -214,20 +235,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                 PropertyFieldMultiSelect('multiSelect', {
                   key: 'multiSelect',
                   label: "Multi select field",
-                  options: [
-                    {
-                      key: "EN",
-                      text: "EN"
-                    },
-                    {
-                      key: "FR",
-                      text: "FR"
-                    },
-                    {
-                      key: "NL",
-                      text: "NL"
-                    }
-                  ],
+                  options: this.multiSelectProps,
                   selectedKeys: this.properties.multiSelect
                 }),
                 PropertyFieldCodeEditor('htmlCode', {

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -108,7 +108,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       id: "Title",
                       title: "Firstname",
                       type: CustomCollectionFieldType.string,
-                      required: true
+                      required: true,
+                      placeholder: "Enter the firstname"
                     },
                     {
                       id: "Lastname",
@@ -119,7 +120,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       id: "Age",
                       title: "Age",
                       type: CustomCollectionFieldType.number,
-                      required: true
+                      required: true,
+                      placeholder: "Enter the age"
                     },
                     {
                       id: "City",
@@ -139,7 +141,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                           text: "Montreal"
                         }
                       ],
-                      required: true
+                      required: true,
+                      placeholder: "Favorite city of the person"
                     },
                     {
                       id: "Sign",
@@ -149,13 +152,15 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                     {
                       id: "IconName",
                       title: "Icon Name",
-                      type: CustomCollectionFieldType.fabricIcon
+                      type: CustomCollectionFieldType.fabricIcon,
+                      placeholder: "Enter the name of the icon"
                     },
                     {
                       id: "URL",
                       title: "URL",
                       type: CustomCollectionFieldType.url,
-                      required: true
+                      required: true,
+                      placeholder: "Enter a URL"
                     }
                   ],
                   disabled: false

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -142,18 +142,21 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                         }
                       ],
                       required: true,
-                      placeholder: "Favorite city of the person"
+                      placeholder: "Favorite city of the person",
+                      defaultValue: "antwerp"
                     },
                     {
                       id: "Sign",
                       title: "Signed",
-                      type: CustomCollectionFieldType.boolean
+                      type: CustomCollectionFieldType.boolean,
+                      defaultValue: true
                     },
                     {
                       id: "IconName",
                       title: "Icon Name",
                       type: CustomCollectionFieldType.fabricIcon,
-                      placeholder: "Enter the name of the icon"
+                      placeholder: "Enter the name of the icon",
+                      defaultValue: "website"
                     },
                     {
                       id: "URL",


### PR DESCRIPTION
**Enhancements**

- `PropertyFieldCollectionData`: Added custom validation for `string`, `number`, `icon`, and `URL` field types [#74](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/74)
- `PropertyFieldCollectionData`: Add an option to specify a default value [#86](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/86)
- `PropertyFieldCollectionData`: override placeholder for the inputs [#87](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/87)
- `PropertyFieldCollectionData`: Hide save button when "Add and save" is shown [#88](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/88)

**Fixes**

- `PropertyFieldMultiSelect`: fixed an issue where the control didn't retain the preselected values when dropdown options were provided async [#85](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/85)
- `PropertyFieldOrder`: fixed an issue where items where provided async [#81](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/81)