### PR TITLE
Removed redundant 'Description' label

### DIFF
--- a/src/propertyFields/webPartInformation/PropertyPaneWebPartInformationHost.tsx
+++ b/src/propertyFields/webPartInformation/PropertyPaneWebPartInformationHost.tsx
@@ -36,7 +36,6 @@ export default class PropertyPaneWebPartInformationHost extends React.Component<
 
     return (
       <div>
-        <PropertyFieldHeader label={strings.DescriptionLabel}  ></PropertyFieldHeader>
         <div dangerouslySetInnerHTML={{ __html: this.props.description }}></div>
 
         {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]

Cleans up the rendering of the webpartinformation control to remove a somewhat redundant 'description' label.