### PR TITLE
Merge for v1.13.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,11 +6,12 @@
         "new": [
         ],
         "enhancements": [
-          "`PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)",
+          "`PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)",
           "`PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)",
           "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
         ],
         "fixes": [
+          "`PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)",
           "`PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)",
           "`PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)",
           "`PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)"

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,10 +6,10 @@
         "new": [
         ],
         "enhancements": [
+          "Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0 [#105](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/105)",
           "`PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)",
           "`PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)",
-          "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)",
-          "Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0"
+          "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
         ],
         "fixes": [
           "`PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -9,7 +9,8 @@
         ],
         "fixes": [
           "`PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)",
-          "`PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)"
+          "`PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)",
+          "`PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)"
         ]
       },
       "contributions": ["[Erwin van Hunen](https://github.com/erwinvanhunen)"]

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,6 +6,7 @@
         "new": [
         ],
         "enhancements": [
+          "`PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)",
           "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
         ],
         "fixes": [

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,6 +6,7 @@
         "new": [
         ],
         "enhancements": [
+          "`PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)",
           "`PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)",
           "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
         ],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,6 +6,7 @@
         "new": [
         ],
         "enhancements": [
+          "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
         ],
         "fixes": [
           "`PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -8,7 +8,8 @@
         "enhancements": [
           "`PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)",
           "`PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)",
-          "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)"
+          "`PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)",
+          "Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0"
         ],
         "fixes": [
           "`PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -20,7 +20,7 @@
           "`PropertyFieldCollectionData`: Fixed catastrophic backtracking regex issue for URL validation [#99](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/99)"
         ]
       },
-      "contributions": ["[Junle Li](https://github.com/lijunle)", "[PooLP](https://github.com/PooLP)", "[Erwin van Hunen](https://github.com/erwinvanhunen)"]
+      "contributions": ["[Paul Bullock](https://github.com/pkbullock)", "[Junle Li](https://github.com/lijunle)", "[PooLP](https://github.com/PooLP)", "[Erwin van Hunen](https://github.com/erwinvanhunen)"]
     },
     {
       "version": "1.11.0",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,20 @@
 {
   "versions": [
     {
+      "version": "1.13.0",
+      "changes": {
+        "new": [
+        ],
+        "enhancements": [
+        ],
+        "fixes": [
+          "`PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)",
+          "`PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)"
+        ]
+      },
+      "contributions": ["[Erwin van Hunen](https://github.com/erwinvanhunen)"]
+    },
+    {
       "version": "1.12.0",
       "changes": {
         "new": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 **Enhancements**
 
+- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0 [#105](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/105)
 - `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
-- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
 - `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
+- `PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 **Enhancements**
 
-- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
+- `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 
 **Fixes**
 
+- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
 - `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
 - `PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Contributors
 
-Special thanks to our contributors (in alphabetical order): [Junle Li](https://github.com/lijunle), [PooLP](https://github.com/PooLP), [Erwin van Hunen](https://github.com/erwinvanhunen).
+Special thanks to our contributors (in alphabetical order): [Paul Bullock](https://github.com/pkbullock), [Junle Li](https://github.com/lijunle), [PooLP](https://github.com/PooLP), [Erwin van Hunen](https://github.com/erwinvanhunen).
 
 ## 1.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 
 **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.13.0
 
+**Enhancements**
+
+- `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
+
 **Fixes**
 
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Releases
 
+## 1.13.0
+
+**Fixes**
+
+- `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
+- `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
+
+### Contributors
+
+Special thanks to our contributor: [Erwin van Hunen](https://github.com/erwinvanhunen).
+
 ## 1.12.0
 
 **New control(s)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
+- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0
 
 **Fixes**
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,10 +4,10 @@
 
 **Enhancements**
 
+- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0 [#105](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/105)
 - `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
-- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0
 
 **Fixes**
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -6,6 +6,7 @@
 
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
 - `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
+- `PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)
 
 ### Contributors
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,12 +4,13 @@
 
 **Enhancements**
 
-- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
+- `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 
 **Fixes**
 
+- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
 - `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
 - `PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -23,7 +23,7 @@
 
 ### Contributors
 
-Special thanks to our contributors (in alphabetical order): [Junle Li](https://github.com/lijunle), [PooLP](https://github.com/PooLP), [Erwin van Hunen](https://github.com/erwinvanhunen).
+Special thanks to our contributors (in alphabetical order): [Paul Bullock](https://github.com/pkbullock), [Junle Li](https://github.com/lijunle), [PooLP](https://github.com/PooLP), [Erwin van Hunen](https://github.com/erwinvanhunen).
 
 ## 1.11.0
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 
 **Fixes**

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -2,6 +2,10 @@
 
 ## 1.13.0
 
+**Enhancements**
+
+- `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
+
 **Fixes**
 
 - `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,16 @@
 # Releases
 
+## 1.13.0
+
+**Fixes**
+
+- `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
+- `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
+
+### Contributors
+
+Special thanks to our contributor: [Erwin van Hunen](https://github.com/erwinvanhunen).
+
 ## 1.12.0
 
 **New control(s)**

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -7,6 +7,7 @@
 - `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
 - `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
 - `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)
+- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0
 
 **Fixes**
 

--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -95,16 +95,17 @@ PropertyFieldCollectionData("collectionData", {
 
 The `PropertyFieldCollectionData` control can be configured with the following properties:
 
-| Property | Type | Required | Description |
+| Property | Type | Required | Description | Default Value |
 | ---- | ---- | ---- | ---- |
-| key | string | yes | An unique key that indicates the identity of this control. |
-| label | string | yes | Property field label displayed on top. |
-| panelHeader | string | yes | Label to be used as the header in the panel. |
-| panelDescription | string | no | Property that allows you to specify a description in the collection panel. |
-| manageBtnLabel | string | yes | Label of the button to open the panel. |
-| fields | ICustomCollectionField[] | yes | The fields to be used for the list of collection data. |
-| value | string | yes | The collection data value. |
-| disabled | boolean | no | Specify if the control is disabled. |
+| key | string | yes | An unique key that indicates the identity of this control. | |
+| label | string | yes | Property field label displayed on top. | |
+| panelHeader | string | yes | Label to be used as the header in the panel. | |
+| panelDescription | string | no | Property that allows you to specify a description in the collection panel. | |
+| manageBtnLabel | string | yes | Label of the button to open the panel. | |
+| fields | ICustomCollectionField[] | yes | The fields to be used for the list of collection data. | |
+| value | string | yes | The collection data value. | |
+| enableSorting | boolean | no | Specify if you want to be able to sort the items in the collection. | false |
+| disabled | boolean | no | Specify if the control is disabled. | false |
 
 Interface `ICustomCollectionField`
 

--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -91,6 +91,25 @@ PropertyFieldCollectionData("collectionData", {
 })
 ```
 
+### Sample of custom field rendering
+
+Here is an example of how you can render your own controls in the `PropertyFieldCollectionData` control:
+
+```TypeScript
+{
+  id: "customFieldId",
+  title: "Custom Field",
+  type: CustomCollectionFieldType.custom,
+  onCustomRender: (field, value, onUpdate) => {
+    return (
+      React.createElement("div", null,
+        React.createElement("input", { value: value, onChange: (event: React.FormEvent<HTMLInputElement>) => onUpdate(field.id, event.currentTarget.value) }), " 🎉"
+      )
+    );
+  }
+}
+```
+
 ## Implementation
 
 The `PropertyFieldCollectionData` control can be configured with the following properties:
@@ -121,6 +140,7 @@ Interface `ICustomCollectionField`
 | defaultValue | any | no | Specify a default value for the input field. |
 | deferredValidationTime | number | no | Field will start to validate after users stop typing for `deferredValidationTime` milliseconds. Default: 200ms. |
 | onGetErrorMessage | (value: any, index: number, crntItem: any): string \| Promise<string> | no | The method is used to get the validation error message and determine whether the input value is valid or not. It provides you the current row index and the item you are currently editing. |
+| onCustomRender | (field: ICustomCollectionField, value: any, onUpdate: (fieldId: string, value: any) => void) => JSX.Element | no | This property is only required if you are using the `custom` field type and it can be used to specify the custom rendering of your control in the collection data. |
 
 Enum `CustomCollectionFieldType`
 
@@ -132,5 +152,6 @@ Enum `CustomCollectionFieldType`
 | dropdown | Dropdown field. You will have to specify the `options` property when using this field type |
 | fabricIcon | Name of the [Office UI Fabric icon](https://developer.microsoft.com/en-us/fabric#/styles/icons) |
 | url | URL field |
+| custom | This gives you control over the whole field rendering. Be sure to provide the `onCustomRender` method to render your control in the collection data. |
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-property-controls/wiki/PropertyFieldCollectionData)

--- a/docs/documentation/docs/controls/PropertyFieldPeoplePicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldPeoplePicker.md
@@ -64,7 +64,8 @@ The `PropertyFieldPeoplePicker` control can be configured with the following pro
 | multiSelect | boolean | no | Define if you want to allow multi user / group selection. (optional, true by default). |
 | principalType | PrincipalType[] | no | Define which type of data you want to retrieve: User, SharePoint groups, Security groups. Multiple are possible. |
 | onPropertyChange | function | yes | Defines a onPropertyChange function to raise when the date gets changed. |
-| properties | any | yes | Parent web part properties, this object is use to update the property value.  |
+| properties | any | yes | Parent web part properties, this object is use to update the property value. |
+| targetSiteUrl | string | no | Specify the URL of the target site from which you want to retreive the users/groups. |
 | key | string | yes | An unique key that indicates the identity of this control. |
 | onGetErrorMessage | function | no | The method is used to get the validation error message and determine whether the input value is valid or not. See [this documentation](https://dev.office.com/sharepoint/docs/spfx/web-parts/guidance/validate-web-part-property-values) to learn how to use it. |
 | deferredValidationTime | number | no | Control will start to validate after users stop typing for `deferredValidationTime` milliseconds. Default value is 200. |

--- a/docs/documentation/mkdocs.yml
+++ b/docs/documentation/mkdocs.yml
@@ -14,6 +14,8 @@ nav:
     - PropertyFieldSpinButton: 'controls/PropertyFieldSpinButton.md'
     - PropertyFieldSwatchColorPicker: 'controls/PropertyFieldSwatchColorPicker.md'
     - PropertyFieldTermPicker: 'controls/PropertyFieldTermPicker.md'
+    - PropertyPanePropertyEditor: 'controls/PropertyPanePropertyEditor.md'
+    - PropertyPaneWebPartInformation: 'controls/PropertyPaneWebPartInformation.md'
   - 'Controls with callout':
     - PropertyFieldButtonWithCallout: 'controls/PropertyFieldButtonWithCallout.md'
     - PropertyFieldCheckboxWithCallout: 'controls/PropertyFieldCheckboxWithCallout.md'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@pnp/telemetry-js": "1.0.0",
-    "react-ace": "5.8.0"
+    "react-ace": "5.8.0",
+    "office-ui-fabric-react": "5.131.0"
   },
   "devDependencies": {
     "@microsoft/sp-build-web": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/spfx-property-controls",
   "description": "Reusable property pane controls for SharePoint Framework solutions",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "1.12.0";
+export const version: string = "1.13.0";

--- a/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCallout.ts
+++ b/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCallout.ts
@@ -10,7 +10,7 @@ import PropertyFieldButtonHost from './PropertyFieldButtonWithCalloutHost';
 
 import { IPropertyFieldButtonWithCalloutPropsInternal, IPropertyFieldButtonWithCalloutProps } from './IPropertyFieldButtonWithCallout';
 import { ButtonType } from 'office-ui-fabric-react/lib/components/Button';
-import * as _ from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Represents a PropertyFieldButtonWithCallout object
@@ -31,16 +31,16 @@ class PropertyFieldButtonWithCalloutBuilder implements IPropertyPaneField<IPrope
 
     private _render(elem: HTMLElement, context?: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
 
-        const props: IPropertyFieldButtonWithCalloutProps = <IPropertyFieldButtonWithCalloutProps>_.omit(this.properties, ['buttonType']);
+        const props: IPropertyFieldButtonWithCalloutProps = <IPropertyFieldButtonWithCalloutProps>omit(this.properties, ['buttonType']);
 
         //
         // PropertyPaneButtonType is not assignable to ButtonType
         //
         const buttonTypeString: string = ButtonType[this.properties.buttonType];
         const buttonType: ButtonType = ButtonType[buttonTypeString];
-
+        const propsWithoutRef = omit(props, "ref");
         const element = React.createElement(PropertyFieldButtonHost, {
-            ...props,
+            ...propsWithoutRef,
             buttonType: buttonType
         });
 

--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
@@ -63,7 +63,7 @@ export default class PropertyFieldCodeEditorHost extends React.Component<IProper
   public componentWillUpdate(nextProps: IPropertyFieldCodeEditorHostProps, nextState: IPropertyFieldCodeEditorHostState): void {
     if (nextProps.initialValue !== this.props.initialValue) {
       this.setState({
-        code: typeof this.props.initialValue !== 'undefined' ? this.props.initialValue : ''
+        code: typeof nextProps.initialValue !== 'undefined' ? nextProps.initialValue : ''
       });
     }
   }

--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
@@ -55,6 +55,20 @@ export default class PropertyFieldCodeEditorHost extends React.Component<IProper
   }
 
   /**
+   * componentWillUpdate lifecycle hook
+   *
+   * @param nextProps
+   * @param nextState
+   */
+  public componentWillUpdate(nextProps: IPropertyFieldCodeEditorHostProps, nextState: IPropertyFieldCodeEditorHostState): void {
+    if (nextProps.initialValue !== this.props.initialValue) {
+      this.setState({
+        code: typeof this.props.initialValue !== 'undefined' ? this.props.initialValue : ''
+      });
+    }
+  }
+
+  /**
    * Open the right Panel
    */
   private onOpenPanel(): void {

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -1,6 +1,6 @@
 import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { IRenderFunction } from '@uifabric/utilities/lib/IRenderFunction';
-import { ISelectableOption } from 'office-ui-fabric-react/lib/utilities/selectableOption/SelectableOption.Props';
+import { ISelectableOption } from 'office-ui-fabric-react/lib/utilities/selectableOption/SelectableOption.types';
 
 export interface ICustomCollectionField {
   /**

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -47,6 +47,11 @@ export interface ICustomCollectionField {
    * - If invalid, the field will show a red border
    */
   onGetErrorMessage?: (value: any, index: number, currentItem: any) => string | Promise<string>;
+
+  /**
+   * Custom field rendering support
+   */
+  onCustomRender?: (field: ICustomCollectionField, value: any, onUpdate: (fieldId: string, value: any) => void) => JSX.Element;
 }
 
 export enum CustomCollectionFieldType {
@@ -55,5 +60,6 @@ export enum CustomCollectionFieldType {
   boolean,
   dropdown,
   fabricIcon,
-  url
+  url,
+  custom
 }

--- a/src/propertyFields/collectionData/IPropertyFieldCollectionData.ts
+++ b/src/propertyFields/collectionData/IPropertyFieldCollectionData.ts
@@ -31,6 +31,10 @@ export interface IPropertyFieldCollectionDataProps {
    */
   value: any[];
   /**
+   * Specify if you want to enable sorting
+   */
+  enableSorting?: boolean;
+  /**
    * Specify if the control is disabled.
    */
   disabled?: boolean;

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -355,6 +355,11 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                           onChanged={(value) => this.onValueChanged(field.id, value)}
                           deferredValidationTime={field.deferredValidationTime || field.deferredValidationTime >= 0 ? field.deferredValidationTime : 200}
                           onGetErrorMessage={async (value: string) => this.urlFieldValidation(field, value, item)} />;
+      case CustomCollectionFieldType.custom:
+          if (field.onCustomRender) {
+            return field.onCustomRender(field, item[field.id], this.onValueChanged);
+          }
+          return null;
       case CustomCollectionFieldType.string:
       default:
         return <TextField placeholder={field.placeholder || field.title}

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -57,25 +57,34 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
       // Update the changed field
       crntItem[fieldId] = value;
 
-      // Check if current item is valid
-      if (this.props.fAddInCreation) {
-        if (this.checkAllRequiredFieldsValid(crntItem) &&
-            this.checkAnyFieldContainsValue(crntItem) &&
-            this.checkAllFieldsAreValid()) {
-          this.props.fAddInCreation(crntItem);
-        } else {
-          this.props.fAddInCreation(null);
-        }
-      }
-
-      // Check if item needs to be updated
-      if (this.props.fUpdateItem) {
-        this.updateItem();
-      }
+      this.doAllFieldChecks();
 
       // Store this in the current state
       return { crntItem };
     });
+  }
+
+  /**
+   * Perform all required field checks at once
+   */
+  private doAllFieldChecks() {
+    const { crntItem } = this.state;
+
+    // Check if current item is valid
+    if (this.props.fAddInCreation) {
+      if (this.checkAllRequiredFieldsValid(crntItem) &&
+          this.checkAnyFieldContainsValue(crntItem) &&
+          this.checkAllFieldsAreValid()) {
+        this.props.fAddInCreation(crntItem);
+      } else {
+        this.props.fAddInCreation(null);
+      }
+    }
+
+    // Check if item needs to be updated
+    if (this.props.fUpdateItem) {
+      this.updateItem();
+    }
   }
 
   /**
@@ -189,17 +198,46 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
     if (field.onGetErrorMessage) {
       // Set initial field validation
       this.validation[field.id] = false;
-      // Trigger field change
-      this.onValueChanged(field.id, value);
       // Do the validation
       validation = await field.onGetErrorMessage(value, this.props.index, this.state.crntItem);
     }
     // Store the field validation
     this.validation[field.id] = validation === "";
-    // Trigger field change
-    this.onValueChanged(field.id, value);
     // Add message for the error callout
     this.errorCalloutHandler(field.id, validation);
+    this.doAllFieldChecks();
+    return validation;
+  }
+
+  /**
+   * URL field validation
+   *
+   * @param field
+   * @param value
+   * @param item
+   */
+  private urlFieldValidation = async (field: ICustomCollectionField, value: any, item: any): Promise<string> => {
+    let isValid = true;
+    let validation = "";
+
+    // Check if custom validation is configured
+    if (field.onGetErrorMessage) {
+      // Using the custom validation
+      validation = await field.onGetErrorMessage(value, this.props.index, item);
+      isValid = validation === "";
+    } else {
+      // Check if entered value is a valid URL
+      const regEx: RegExp = /(http|https)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/;
+      isValid = (value === null || value.length === 0 || regEx.test(value));
+      validation = isValid ? "" : strings.InvalidUrlError;
+    }
+
+    // Store the field validation
+    this.validation[field.id] = isValid;
+    // Add message for the error callout
+    this.errorCalloutHandler(field.id, validation);
+    this.doAllFieldChecks();
+    // Return the error message if needed
     return validation;
   }
 
@@ -314,41 +352,18 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
                           className={styles.collectionDataField}
+                          onChanged={(value) => this.onValueChanged(field.id, value)}
                           deferredValidationTime={field.deferredValidationTime || field.deferredValidationTime >= 0 ? field.deferredValidationTime : 200}
-                          onGetErrorMessage={async (value) => {
-                            let isValid = true;
-                            let validation = "";
-
-                            // Check if custom validation is configured
-                            if (field.onGetErrorMessage) {
-                              // Using the custom validation
-                              validation = await field.onGetErrorMessage(value, this.props.index, item);
-                              isValid = validation === "";
-                            } else {
-                              // Check if entered value is a valid URL
-                              const regEx: RegExp = /(http|https)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/;
-                              isValid = (value === null || value.length === 0 || regEx.test(value));
-                              validation = isValid ? "" : strings.InvalidUrlError;
-                            }
-
-                            // Store the field validation
-                            this.validation[field.id] = isValid;
-                            // Trigger field change
-                            this.onValueChanged(field.id, value);
-                            // Add message for the error callout
-                            this.errorCalloutHandler(field.id, validation);
-                            // Return the error message if needed
-                            return validation;
-                          }} />;
+                          onGetErrorMessage={async (value: string) => this.urlFieldValidation(field, value, item)} />;
       case CustomCollectionFieldType.string:
       default:
         return <TextField placeholder={field.placeholder || field.title}
                           className={styles.collectionDataField}
                           value={item[field.id] ? item[field.id] : ""}
                           required={field.required}
-                          // onChanged={(value) => this.onValueChanged(field.id, value)}
+                          onChanged={(value) => this.onValueChanged(field.id, value)}
                           deferredValidationTime={field.deferredValidationTime || field.deferredValidationTime >= 0 ? field.deferredValidationTime : 200}
-                          onGetErrorMessage={(value: string) => this.fieldValidation(field, value)} />;
+                          onGetErrorMessage={async (value: string) => await this.fieldValidation(field, value)} />;
     }
   }
 

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -7,7 +7,7 @@ import { Link } from 'office-ui-fabric-react/lib/components/Link';
 import { Checkbox } from 'office-ui-fabric-react/lib/components/Checkbox';
 import * as strings from 'PropertyControlStrings';
 import { ICustomCollectionField, CustomCollectionFieldType, FieldValidator } from '..';
-import { Dropdown } from 'office-ui-fabric-react/lib/components/Dropdown';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/components/Dropdown';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/components/Callout';
 import { CollectionIconField } from '../collectionIconField';
 import { clone, findIndex, sortBy } from '@microsoft/sp-lodash-subset';
@@ -368,13 +368,41 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
   }
 
   /**
+   * Retrieve all dropdown options
+   */
+  private getSortingOptions(): IDropdownOption[] {
+    let opts: IDropdownOption[] = [];
+    const { totalItems } = this.props;
+    for (let i = 1; i <= totalItems; i++) {
+      opts.push({
+        text: i.toString(),
+        key: i
+      });
+    }
+    return opts;
+  }
+
+  /**
    * Default React render
    */
   public render(): React.ReactElement<ICollectionDataItemProps> {
     const { crntItem } = this.state;
+    const opts = this.getSortingOptions();
 
     return (
       <div className={`${styles.tableRow} ${this.props.index === null ? styles.tableFooter : ""}`}>
+        {
+          (this.props.sortingEnabled && this.props.totalItems) && (
+            <span className={`${styles.tableCell}`}>
+              <Dropdown options={opts} selectedKey={this.props.index + 1} onChanged={(opt) => this.props.fOnSorting(this.props.index, opt.key as number) } />
+            </span>
+          )
+        }
+        {
+          (this.props.sortingEnabled && this.props.totalItems === null) && (
+            <span className={`${styles.tableCell}`}></span>
+          )
+        }
         {
           this.props.fields.map(f => (
             <span className={`${styles.tableCell} ${styles.inputField}`}>{this.renderField(f, crntItem)}</span>

--- a/src/propertyFields/collectionData/collectionDataItem/ICollectionDataItemProps.ts
+++ b/src/propertyFields/collectionData/collectionDataItem/ICollectionDataItemProps.ts
@@ -4,10 +4,13 @@ export interface ICollectionDataItemProps {
   fields: ICustomCollectionField[];
   index?: number;
   item?: any;
+  sortingEnabled?: boolean;
+  totalItems?: number;
 
   fAddItem?: (item: any) => void;
   fAddInCreation?: (item: any) => void;
   fUpdateItem?: (idx: number, item: any) => void;
   fDeleteItem?: (idx: number) => void;
   fValidation?: (idx: number, isValid: boolean) => void;
+  fOnSorting?: (oldIdx: number, newIdx: number) => void;
 }

--- a/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
+++ b/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
@@ -3,6 +3,7 @@ import styles from '../PropertyFieldCollectionDataHost.module.scss';
 import { Async } from 'office-ui-fabric-react/lib/Utilities';
 import { ICollectionNumberFieldProps, ICollectionNumberFieldState } from '.';
 import { ICustomCollectionField } from '..';
+import { isEqual } from '@microsoft/sp-lodash-subset';
 
 export class CollectionNumberField extends React.Component<ICollectionNumberFieldProps, ICollectionNumberFieldState> {
   private async: Async;
@@ -28,6 +29,20 @@ export class CollectionNumberField extends React.Component<ICollectionNumberFiel
       value: this.props.item[this.props.field.id]
     });
     this.valueChange(this.props.field, this.props.item[this.props.field.id]);
+  }
+
+  /**
+   * componentWillUpdate lifecycle hook
+   *
+   * @param nextProps
+   * @param nextState
+   */
+  public componentWillUpdate(nextProps: ICollectionNumberFieldProps, nextState: ICollectionNumberFieldState): void {
+    if (!isEqual(nextProps.item, this.props.item)) {
+      this.setState({
+        value: nextProps.item[nextProps.field.id]
+      });
+    }
   }
 
   /**

--- a/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
+++ b/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
@@ -41,6 +41,7 @@ export class CollectionNumberField extends React.Component<ICollectionNumberFiel
     this.setState({
       value: inputVal
     });
+    this.props.fOnValueChange(field.id, value);
     this.delayedValidate(field, inputVal);
   }
 
@@ -70,7 +71,7 @@ export class CollectionNumberField extends React.Component<ICollectionNumberFiel
                aria-valuenow={this.props.item[this.props.field.id] || ''}
                aria-invalid={!!this.state.errorMessage}
                value={this.state.value || ''}
-               onChange={(ev) => this.valueChange(this.props.field, ev.target.value)} />
+               onChange={async (ev) => await this.valueChange(this.props.field, ev.target.value)} />
       </div>
     );
   }

--- a/src/propertyFields/dateTimePicker/HoursComponent.tsx
+++ b/src/propertyFields/dateTimePicker/HoursComponent.tsx
@@ -47,7 +47,8 @@ export default class HoursComponent extends React.Component<IHoursComponentProps
         disabled={this.props.disabled}
         label=''
         options={hours}
-        onChanged={this.props.onChange} />
+        onChanged={this.props.onChange}
+        dropdownWidth={110} />
     );
   }
 }

--- a/src/propertyFields/order/PropertyFieldOrderHost.tsx
+++ b/src/propertyFields/order/PropertyFieldOrderHost.tsx
@@ -1,4 +1,3 @@
-import { autobind, EventGroup } from '@uifabric/utilities';
 import { IButtonStyles, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Label } from 'office-ui-fabric-react/lib/Label';
@@ -10,6 +9,7 @@ import * as telemetry from '../../common/telemetry';
 import { IPropertyFieldOrderHostProps, IPropertyFieldOrderHostState } from './IPropertyFieldOrderHost';
 import styles from './PropertyFieldOrderHost.module.scss';
 import { isEqual } from '@microsoft/sp-lodash-subset';
+import { EventGroup } from '@uifabric/utilities/lib/EventGroup';
 
 export default class PropertyFieldOrderHost extends React.Component<IPropertyFieldOrderHostProps, IPropertyFieldOrderHostState> {
 
@@ -154,13 +154,11 @@ export default class PropertyFieldOrderHost extends React.Component<IPropertyFie
 		this.cleanupSubscriptions();
 	}
 
-	@autobind
-	private registerRef(ref:HTMLElement): void {
+	private registerRef = (ref:HTMLElement): void => {
 		this._refs.push(ref);
 	}
 
-	@autobind
-	private setupSubscriptions(): void {
+	private setupSubscriptions = (): void => {
 		if(!this.props.disableDragAndDrop && !this.props.disabled) {
 			this._refs.forEach((value:HTMLElement, index:number) => {
 				this._ddSubs.push(this._ddHelper.subscribe(value, new EventGroup(value), {
@@ -228,16 +226,14 @@ export default class PropertyFieldOrderHost extends React.Component<IPropertyFie
 		}
 	}
 
-	@autobind
-	private cleanupSubscriptions(): void {
+	private cleanupSubscriptions = (): void => {
 		while(this._ddSubs.length){
 			let sub:any = this._ddSubs.pop();
 			sub.dispose();
 		}
 	}
 
-	@autobind
-	private insertBeforeItem(item: any) {
+	private insertBeforeItem = (item: any) => {
 		let itemIndex:number = this.state.items.indexOf(this._draggedItem);
 		let targetIndex:number = this.state.items.indexOf(item);
 		if(itemIndex < targetIndex) {
@@ -247,22 +243,19 @@ export default class PropertyFieldOrderHost extends React.Component<IPropertyFie
 	}
 
 
-	@autobind
-	private onMoveUpClick(itemIndex:number): void {
+	private onMoveUpClick = (itemIndex:number): void => {
 		if(itemIndex > 0) {
 			this.moveItemAtIndexToTargetIndex(itemIndex, itemIndex-1);
 		}
 	}
 
-	@autobind
-	private onMoveDownClick(itemIndex:number): void {
+	private onMoveDownClick = (itemIndex:number): void => {
 		if(itemIndex < this.state.items.length-1) {
 			this.moveItemAtIndexToTargetIndex(itemIndex, itemIndex+1);
 		}
 	}
 
-	@autobind
-	private moveItemAtIndexToTargetIndex(itemIndex:number, targetIndex:number): void {
+	private moveItemAtIndexToTargetIndex = (itemIndex:number, targetIndex:number): void => {
 		if(itemIndex !== targetIndex && itemIndex > -1 && targetIndex > -1 && itemIndex < this.state.items.length && targetIndex < this.state.items.length) {
 			let items: Array<any> = this.state.items;
 			items.splice(targetIndex, 0, ...items.splice(itemIndex, 1)[0]);

--- a/src/propertyFields/peoplePicker/IPropertyFieldPeoplePicker.ts
+++ b/src/propertyFields/peoplePicker/IPropertyFieldPeoplePicker.ts
@@ -93,6 +93,10 @@ export interface IPropertyFieldPeoplePickerProps {
    */
   multiSelect?: boolean;
   /**
+   * Target a specific site to retrieve the users
+   */
+  targetSiteUrl?: string;
+  /**
    * Defines a onPropertyChange function to raise when the selected value changed.
    * Normally this function must be always defined with the 'this.onPropertyChange'
    * method of the web part object.

--- a/src/propertyFields/peoplePicker/PropertyFieldPeoplePicker.ts
+++ b/src/propertyFields/peoplePicker/PropertyFieldPeoplePicker.ts
@@ -29,6 +29,7 @@ class PropertyFieldPeoplePickerBuilder implements IPropertyPaneField<IPropertyFi
   private principalType: PrincipalType[] = [];
   private onPropertyChange: (propertyPath: string, oldValue: any, newValue: any) => void;
   private customProperties: any;
+  private targetSiteUrl: string;
   private key: string;
   private onGetErrorMessage: (value: IPropertyFieldGroupOrPerson[]) => string | Promise<string>;
   private deferredValidationTime: number = 200;
@@ -48,6 +49,7 @@ class PropertyFieldPeoplePickerBuilder implements IPropertyPaneField<IPropertyFi
     this.initialData = _properties.initialData;
     this.allowDuplicate = _properties.allowDuplicate;
     this.principalType = _properties.principalType;
+    this.targetSiteUrl = _properties.targetSiteUrl;
     this.customProperties = _properties.properties;
     this.key = _properties.key;
     this.onGetErrorMessage = _properties.onGetErrorMessage;
@@ -84,6 +86,7 @@ class PropertyFieldPeoplePickerBuilder implements IPropertyPaneField<IPropertyFi
       onPropertyChange: this.onPropertyChange,
       context: this.context,
       properties: this.customProperties,
+      targetSiteUrl: this.targetSiteUrl,
       key: this.key,
       onGetErrorMessage: this.onGetErrorMessage,
       deferredValidationTime: this.deferredValidationTime

--- a/src/propertyFields/peoplePicker/PropertyFieldPeoplePickerHost.tsx
+++ b/src/propertyFields/peoplePicker/PropertyFieldPeoplePickerHost.tsx
@@ -61,7 +61,7 @@ export default class PropertyFieldPeoplePickerHost extends React.Component<IProp
       // Clear the suggestions list
       this.setState({ resultsPeople: this.resultsPeople, resultsPersonas: this.resultsPersonas });
       // Request the search service
-      const result = this.searchService.searchPeople(this.props.context, searchText, this.props.principalType).then((response: IPropertyFieldGroupOrPerson[]) => {
+      const result = this.searchService.searchPeople(this.props.context, searchText, this.props.principalType, this.props.targetSiteUrl).then((response: IPropertyFieldGroupOrPerson[]) => {
         this.resultsPeople = [];
         this.resultsPersonas = [];
         // If allowDuplicate == false, so remove duplicates from results

--- a/src/propertyFields/peoplePicker/PropertyFieldPeoplePickerHost.tsx
+++ b/src/propertyFields/peoplePicker/PropertyFieldPeoplePickerHost.tsx
@@ -79,8 +79,7 @@ export default class PropertyFieldPeoplePickerHost extends React.Component<IProp
         return this.resultsPersonas;
       });
       return result;
-    }
-    else {
+    } else {
       return [];
     }
   }
@@ -134,8 +133,12 @@ export default class PropertyFieldPeoplePickerHost extends React.Component<IProp
    */
   private getPersonaFromPeople(element: IPropertyFieldGroupOrPerson, index: number): IPersonaProps {
     return {
-      primaryText: element.fullName, secondaryText: element.jobTitle, imageUrl: element.imageUrl,
-      imageInitials: element.initials, presence: PersonaPresence.none, initialsColor: this.getRandomInitialsColor(index)
+      primaryText: element.fullName,
+      secondaryText: element.jobTitle,
+      imageUrl: element.imageUrl,
+      imageInitials: element.initials,
+      presence: PersonaPresence.none,
+      initialsColor: this.getRandomInitialsColor(index)
     };
   }
 

--- a/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCalloutHost.tsx
+++ b/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCalloutHost.tsx
@@ -6,6 +6,7 @@ import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldH
 import { IPropertyFieldSliderWithCalloutHostProps } from './IPropertyFieldSliderWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
 import { Slider } from 'office-ui-fabric-react/lib/components/Slider';
+import { omit } from 'lodash';
 
 export default class PropertyFieldSliderWithCalloutHost extends React.Component<IPropertyFieldSliderWithCalloutHostProps, null> {
   constructor(props: IPropertyFieldSliderWithCalloutHostProps) {
@@ -19,7 +20,7 @@ export default class PropertyFieldSliderWithCalloutHost extends React.Component<
   public render(): JSX.Element {
     return (
       <div>
-        <PropertyFieldHeader {...this.props} />
+        <PropertyFieldHeader {...omit(this.props, "ref")} />
         <Slider {..._.omit(this.props, ['label'])} />
       </div>
     );

--- a/src/services/ISPPeopleSearchService.ts
+++ b/src/services/ISPPeopleSearchService.ts
@@ -11,5 +11,5 @@ export interface ISPPeopleSearchService {
   /**
    * Search People from a query
    */
-  searchPeople(ctx: IWebPartContext, query: string, principleType: PrincipalType[]): Promise<Array<IPropertyFieldGroupOrPerson>>;
+  searchPeople(ctx: IWebPartContext, query: string, principleType: PrincipalType[], siteUrl?: string): Promise<Array<IPropertyFieldGroupOrPerson>>;
 }

--- a/src/services/IUsers.ts
+++ b/src/services/IUsers.ts
@@ -1,0 +1,25 @@
+export interface IUsers {
+  '@odata.context': string;
+  value: Value[];
+}
+
+export interface Value {
+  '@odata.type': string;
+  '@odata.id': string;
+  '@odata.editLink': string;
+  Id: number;
+  IsHiddenInUI: boolean;
+  LoginName: string;
+  Title: string;
+  PrincipalType: number;
+  Email: string;
+  IsEmailAuthenticationGuestUser: boolean;
+  IsShareByEmailGuestUser: boolean;
+  IsSiteAdmin: boolean;
+  UserId?: UserId;
+}
+
+export interface UserId {
+  NameId: string;
+  NameIdIssuer: string;
+}

--- a/src/services/SPPeopleSearchService.ts
+++ b/src/services/SPPeopleSearchService.ts
@@ -4,6 +4,7 @@ import { PrincipalType, IPropertyFieldGroupOrPerson } from './../propertyFields/
 import { ISPPeopleSearchService } from './ISPPeopleSearchService';
 import SPPeoplePickerMockHttpClient from './SPPeopleSearchMockService';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { IUsers } from './IUsers';
 
 /**
  * Service implementation to search people in SharePoint
@@ -12,82 +13,113 @@ export default class SPPeopleSearchService implements ISPPeopleSearchService {
   /**
    * Search people from the SharePoint People database
    */
-  public searchPeople(ctx: IWebPartContext, query: string, principalType: PrincipalType[]): Promise<Array<IPropertyFieldGroupOrPerson>> {
+  public searchPeople(ctx: IWebPartContext, query: string, principalType: PrincipalType[], siteUrl: string = null): Promise<IPropertyFieldGroupOrPerson[]> {
     if (Environment.type === EnvironmentType.Local) {
       // If the running environment is local, load the data from the mock
       return this.searchPeopleFromMock(ctx, query);
     } else {
-      // If the running env is SharePoint, loads from the peoplepicker web service
-      const userRequestUrl: string = `${ctx.pageContext.web.absoluteUrl}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`;
-      const data = {
-        'queryParams': {
-          'AllowEmailAddresses': true,
-          'AllowMultipleEntities': false,
-          'AllUrlZones': false,
-          'MaximumEntitySuggestions': 20,
-          'PrincipalSource': 15,
-          // PrincipalType controls the type of entities that are returned in the results.
-          // Choices are All - 15, Distribution List - 2 , Security Groups - 4, SharePoint Groups - 8, User - 1.
-          // These values can be combined (example: 13 is security + SP groups + users)
-          'PrincipalType': !!principalType && principalType.length > 0 ? principalType.reduce((a, b) => a + b, 0) : 1,
-          'QueryString': query
+      // Check the type of action to perform (gobal or local)
+      if (siteUrl) {
+        let userRequestUrl = `${siteUrl}/_api/web/siteusers`;
+        // filter for principal Type
+        let filterVal: string = `?$filter=(substringof('${query}', Title) or substringof('${query}', LoginName))`;
+        if (principalType) {
+          filterVal = `${filterVal} and (${principalType.map(type => `(PrincipalType eq ${type})`).join(" or ")})`;
         }
-      };
-      let httpPostOptions: ISPHttpClientOptions = {
-        headers: {
-          'accept': 'application/json',
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify(data)
-      };
+        // Filter for hidden values
+        filterVal = `${filterVal} and (IsHiddenInUI eq false)`;
+        userRequestUrl = `${userRequestUrl}${filterVal}`;
 
-      // Do the call against the People REST API endpoint
-      return ctx.spHttpClient.post(userRequestUrl, SPHttpClient.configurations.v1, httpPostOptions).then((searchResponse: SPHttpClientResponse) => {
-        return searchResponse.json().then((usersResponse: any) => {
-          const res: IPropertyFieldGroupOrPerson[] = [];
-          const values: any = JSON.parse(usersResponse.value);
-          values.map(element => {
-            switch (element.EntityType) {
-              case 'User':
-                const groupOrPerson: IPropertyFieldGroupOrPerson = { fullName: element.DisplayText, login: element.Description };
-                groupOrPerson.email = element.EntityData.Email;
-                groupOrPerson.jobTitle = element.EntityData.Title;
-                groupOrPerson.initials = this.getFullNameInitials(groupOrPerson.fullName);
-                groupOrPerson.imageUrl = this.getUserPhotoUrl(groupOrPerson.email, ctx.pageContext.web.absoluteUrl);
-                res.push(groupOrPerson);
-                break;
-              case 'SecGroup':
-                const group: IPropertyFieldGroupOrPerson = {
-                  fullName: element.DisplayText,
-                  login: element.ProviderName,
-                  id: element.Key,
-                  description: element.Description
-                };
-                res.push(group);
-                break;
-              case 'FormsRole':
-                const formsRole: IPropertyFieldGroupOrPerson = {
-                  fullName: element.DisplayText,
-                  login: element.ProviderName,
-                  id: element.Key,
-                  description: element.Description
-                };
-                res.push(formsRole);
-                break;
-              default:
-                const persona: IPropertyFieldGroupOrPerson = {
-                  fullName: element.DisplayText,
-                  login: element.EntityData.AccountName,
-                  id: element.EntityData.SPGroupID,
-                  description: element.Description
-                };
-                res.push(persona);
-                break;
-            }
-          });
+        return ctx.spHttpClient.get(userRequestUrl, SPHttpClient.configurations.v1, {
+          headers: {
+            'Accept': 'application/json;odata.metadata=none'
+          }
+        })
+        .then(data => data.json())
+        .then((usersData: IUsers) => {
+          let res: IPropertyFieldGroupOrPerson[] = [];
+
+          if (usersData && usersData.value && usersData.value.length > 0) {
+            res = usersData.value.map(element => ({
+              fullName: element.Title,
+              id: element.Id.toString(),
+              login: element.LoginName,
+              email: element.Email,
+              imageUrl: this.getUserPhotoUrl(element.Email, siteUrl),
+              initials: this.getFullNameInitials(element.Title)
+            } as IPropertyFieldGroupOrPerson));
+          }
           return res;
         });
-      });
+      } else {
+        // If the running env is SharePoint, loads from the peoplepicker web service
+        const userRequestUrl: string = `${ctx.pageContext.web.absoluteUrl}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`;
+        const data = {
+          'queryParams': {
+            'AllowEmailAddresses': true,
+            'AllowMultipleEntities': false,
+            'AllUrlZones': false,
+            'MaximumEntitySuggestions': 20,
+            'PrincipalSource': 15,
+            // PrincipalType controls the type of entities that are returned in the results.
+            // Choices are All - 15, Distribution List - 2 , Security Groups - 4, SharePoint Groups - 8, User - 1.
+            // These values can be combined (example: 13 is security + SP groups + users)
+            'PrincipalType': !!principalType && principalType.length > 0 ? principalType.reduce((a, b) => a + b, 0) : 1,
+            'QueryString': query
+          }
+        };
+        let httpPostOptions: ISPHttpClientOptions = {
+          headers: {
+            'accept': 'application/json',
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify(data)
+        };
+
+        // Do the call against the People REST API endpoint
+        return ctx.spHttpClient.post(userRequestUrl, SPHttpClient.configurations.v1, httpPostOptions).then((searchResponse: SPHttpClientResponse) => {
+          return searchResponse.json().then((usersResponse: any) => {
+            let res: IPropertyFieldGroupOrPerson[] = [];
+            const values: any = JSON.parse(usersResponse.value);
+            res = values.map(element => {
+              switch (element.EntityType) {
+                case 'User':
+                  const groupOrPerson: IPropertyFieldGroupOrPerson = { fullName: element.DisplayText, login: element.Description };
+                  groupOrPerson.email = element.EntityData.Email;
+                  groupOrPerson.jobTitle = element.EntityData.Title;
+                  groupOrPerson.initials = this.getFullNameInitials(groupOrPerson.fullName);
+                  groupOrPerson.imageUrl = this.getUserPhotoUrl(groupOrPerson.email, ctx.pageContext.web.absoluteUrl);
+                  return groupOrPerson;
+                case 'SecGroup':
+                  const group: IPropertyFieldGroupOrPerson = {
+                    fullName: element.DisplayText,
+                    login: element.ProviderName,
+                    id: element.Key,
+                    description: element.Description
+                  };
+                  return group;
+                case 'FormsRole':
+                  const formsRole: IPropertyFieldGroupOrPerson = {
+                    fullName: element.DisplayText,
+                    login: element.ProviderName,
+                    id: element.Key,
+                    description: element.Description
+                  };
+                  return formsRole;
+                default:
+                  const persona: IPropertyFieldGroupOrPerson = {
+                    fullName: element.DisplayText,
+                    login: element.EntityData.AccountName,
+                    id: element.EntityData.SPGroupID,
+                    description: element.Description
+                  };
+                  return persona;
+              }
+            });
+            return res;
+          });
+        });
+      }
     }
   }
 
@@ -113,7 +145,10 @@ export default class SPPeopleSearchService implements ISPPeopleSearchService {
    * Gets the user photo url
    */
   private getUserPhotoUrl(userEmail: string, siteUrl: string): string {
-    return `${siteUrl}/_layouts/15/userphoto.aspx?size=S&accountname=${userEmail}`;
+    if (userEmail) {
+      return `${siteUrl}/_layouts/15/userphoto.aspx?size=S&accountname=${userEmail}`;
+    }
+    return null;
   }
 
 

--- a/src/services/SPPeopleSearchService.ts
+++ b/src/services/SPPeopleSearchService.ts
@@ -22,12 +22,12 @@ export default class SPPeopleSearchService implements ISPPeopleSearchService {
       if (siteUrl) {
         let userRequestUrl = `${siteUrl}/_api/web/siteusers`;
         // filter for principal Type
-        let filterVal: string = `?$filter=(substringof('${query}', Title) or substringof('${query}', LoginName))`;
+        let filterVal: string = "";
         if (principalType) {
-          filterVal = `${filterVal} and (${principalType.map(type => `(PrincipalType eq ${type})`).join(" or ")})`;
+          filterVal = `?$filter=(${principalType.map(type => `(PrincipalType eq ${type})`).join(" or ")})`;
         }
         // Filter for hidden values
-        filterVal = `${filterVal} and (IsHiddenInUI eq false)`;
+        filterVal = filterVal ? `${filterVal} and (IsHiddenInUI eq false)` : `?$filter=(IsHiddenInUI eq false)`;
         userRequestUrl = `${userRequestUrl}${filterVal}`;
 
         return ctx.spHttpClient.get(userRequestUrl, SPHttpClient.configurations.v1, {
@@ -40,7 +40,7 @@ export default class SPPeopleSearchService implements ISPPeopleSearchService {
           let res: IPropertyFieldGroupOrPerson[] = [];
 
           if (usersData && usersData.value && usersData.value.length > 0) {
-            res = usersData.value.map(element => ({
+            res = usersData.value.filter(element => element.Title.toLowerCase().indexOf(query.toLowerCase()) !== -1 || element.LoginName.toLowerCase().indexOf(query.toLowerCase()) !== -1).map(element => ({
               fullName: element.Title,
               id: element.Id.toString(),
               login: element.LoginName,

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -228,6 +228,18 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       type: CustomCollectionFieldType.url,
                       required: true,
                       placeholder: "Enter a URL"
+                    },
+                    {
+                      id: "custom",
+                      title: "Custom Field",
+                      type: CustomCollectionFieldType.custom,
+                      onCustomRender: (field, value, onUpdate) => {
+                        return (
+                          React.createElement("div", null,
+                            React.createElement("input", { value: value, onChange: (event: React.FormEvent<HTMLInputElement>) => onUpdate(field.id, event.currentTarget.value) }), " 🎉"
+                          )
+                        );
+                      }
                     }
                   ],
                   disabled: false

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -248,7 +248,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   label: 'PropertyFieldPeoplePicker',
                   initialData: this.properties.people,
                   allowDuplicate: false,
-                  principalType: [PrincipalType.Security],
+                  // principalType: [PrincipalType.Security],
+                  principalType: [PrincipalType.Users, PrincipalType.SharePoint, PrincipalType.Security],
                   // principalType: [PrincipalType.Users, PrincipalType.SharePoint, PrincipalType.Security],
                   // principalType: [IPrincipalType.SharePoint],
                   multiSelect: true,
@@ -260,7 +261,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                     return users.length === 0 ? 'Please use a person with "Elio" in its name' : "";
                   },
                   deferredValidationTime: 0,
-                  key: 'peopleFieldId'
+                  key: 'peopleFieldId',
+                  targetSiteUrl: this.context.pageContext.site.absoluteUrl
                 }),
                 PropertyFieldTermPicker('terms', {
                   label: 'Select terms',

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -154,6 +154,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   manageBtnLabel: "Manage collection data",
                   panelDescription: "This is the description which appears in the panel.",
                   value: this.properties.collectionData,
+                  enableSorting: true,
                   fields: [
                     {
                       id: "Title",

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -88,8 +88,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
     return new Promise(resolve => {
       setTimeout(() => {
         console.log(`Currently editing item nr: ${index === null ? "new item" : index}. It contains the following properties:`, item);
-        return value.length >= 3 ? resolve("") : resolve("Should at least contain 3 characters.");
-      }, (Math.floor(Math.random() * 4) + 1) * 1000); // Random number between 1 - 4
+        value.length >= 3 ? resolve("") : resolve("Should at least contain 3 characters.");
+      }, (Math.floor(Math.random() * 4) + 1) * 100); // Random number between 1 - 4
     });
   }
 
@@ -162,7 +162,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                       required: true,
                       placeholder: "Enter the firstname",
                       onGetErrorMessage: this.minLengthValidation,
-                      deferredValidationTime: 1000
+                      deferredValidationTime: 500
                     },
                     {
                       id: "Lastname",

--- a/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
+++ b/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
@@ -39,7 +39,7 @@ export default class PropertyControlsTest extends React.Component<IPropertyContr
               <p className="ms-font-m ms-fontColor-neutralDark">Text Info Header Value: {this.props.textInfoHeaderValue}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Toggle Info Header Value: {this.props.toggleInfoHeaderValue ? 'Marvel' : 'DC Comics'}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Checkbox with Callout Value: {(this.props.checkboxWithCalloutValue || '').toString()}</p>
-              <p className="ms-font-m ms-fontColor-neutralDark">Collection data: {JSON.stringify(this.props.collectionData)}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark" style={{wordBreak:"break-all"}}>Collection data: {JSON.stringify(this.props.collectionData)}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Ordered Items: {this.props.orderedItems.map((value: any) => {
                 return (
                   <i

--- a/src/webparts/propertyControlsTest/testcomponent.tsx
+++ b/src/webparts/propertyControlsTest/testcomponent.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export interface IComponentProps {}
+
+export interface IComponentState {}
+
+export default class Component extends React.Component<IComponentProps, IComponentState> {
+  constructor(props: IComponentProps) {
+    super(props);
+
+    this.state = {
+
+    };
+  }
+
+  public render(): React.ReactElement<IComponentProps> {
+    return (
+      <div>
+        <input value="nothing" onChange={null} /> 🎉
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
**Enhancements**

- Updated the `office-ui-fabric-react` to the same version as in SPFx 1.7.0 [#105](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/105)
- `PropertyFieldPeoplePicker`: Ability to select only from a specific site [#9](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/9)
- `PropertyFieldCodeEditor`: Added support for custom field rendering [#122](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/122)
- `PropertyFieldCodeEditor`: Added the functionality to sort the items in the collection [#123](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/123)

**Fixes**

- `PropertyFieldDateTimePicker`: Fix for the hours dropdown not showing values [#112](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/112)
- `PropertyFieldCollectionData`: Issue with debounce validation overriding the inserted values [#113](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/113)
- `PropertyPaneWebPartInformation`: Remove redundant 'Description' label [#119](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/119)
- `PropertyFieldCodeEditor`: Handle initial value after updating properties [#121](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/121)

### Contributors

Special thanks to our contributor: [Erwin van Hunen](https://github.com/erwinvanhunen).