### PR TITLE
Fixed bugs with custom field types and display bug with dropdown in IE

### DIFF
--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -51,7 +51,7 @@ export interface ICustomCollectionField {
   /**
    * Custom field rendering support
    */
-  onCustomRender?: (field: ICustomCollectionField, value: any, onUpdate: (fieldId: string, value: any) => void) => JSX.Element;
+  onCustomRender?: (field: ICustomCollectionField, value: any, onUpdate: (fieldId: string, value: any) => void, rowUniqueId: string) => JSX.Element;
 }
 
 export enum CustomCollectionFieldType {

--- a/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.module.scss
+++ b/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.module.scss
@@ -124,6 +124,7 @@
 .tableCell {
   display: table-cell;
   padding: 0 10px;
+  vertical-align: middle;
 
   > div {
     margin-bottom: 8px;

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as uuid from "uuid";
 import styles from '../PropertyFieldCollectionDataHost.module.scss';
 import { ICollectionDataItemProps, ICollectionDataItemState } from '.';
 import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
@@ -23,6 +24,8 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
 
     // Create an empty item with all properties
     this.emptyItem = {};
+    this.emptyItem.uniqueId = uuid();
+
     for (const field of this.props.fields) {
       // Assign default value or null to the emptyItem
       this.emptyItem[field.id] = field.defaultValue || null;
@@ -149,10 +152,6 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
           this.checkAnyFieldContainsValue(crntItem) &&
           this.checkAllFieldsAreValid()) {
         this.props.fAddItem(crntItem);
-        // Clear all field values
-        this.setState({
-          crntItem: {...this.emptyItem}
-        });
       }
     }
   }

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -23,16 +23,10 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
     super(props);
 
     // Create an empty item with all properties
-    this.emptyItem = {};
-    this.emptyItem.uniqueId = uuid();
-
-    for (const field of this.props.fields) {
-      // Assign default value or null to the emptyItem
-      this.emptyItem[field.id] = field.defaultValue || null;
-    }
+    let emptyItem = this.generateEmptyItem();
 
     this.state = {
-      crntItem: clone(this.props.item) || {...this.emptyItem},
+      crntItem: clone(this.props.item) || {...emptyItem},
       errorMsgs: [],
       showCallout: false
     };
@@ -152,6 +146,11 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
           this.checkAnyFieldContainsValue(crntItem) &&
           this.checkAllFieldsAreValid()) {
         this.props.fAddItem(crntItem);
+        // Clear all field values
+        let emptyItem = this.generateEmptyItem();
+        this.setState({
+          crntItem: {...emptyItem}
+        });
       }
     }
   }
@@ -356,7 +355,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                           onGetErrorMessage={async (value: string) => this.urlFieldValidation(field, value, item)} />;
       case CustomCollectionFieldType.custom:
           if (field.onCustomRender) {
-            return field.onCustomRender(field, item[field.id], this.onValueChanged);
+            return field.onCustomRender(field, item[field.id], this.onValueChanged, item.uniqueId);
           }
           return null;
       case CustomCollectionFieldType.string:
@@ -384,6 +383,21 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
       });
     }
     return opts;
+  }
+
+   /**
+   * Creates an empty item with a unique id
+   */
+  private generateEmptyItem(): any {
+    // Create an empty item with all properties
+    let emptyItem:any = {};
+    emptyItem.uniqueId = uuid();
+    
+    for (const field of this.props.fields) {
+      // Assign default value or null to the emptyItem
+      emptyItem[field.id] = field.defaultValue || null;
+    }
+    return emptyItem;
   }
 
   /**

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -216,7 +216,7 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
           {
             (this.state.crntItems && this.state.crntItems.length > 0) && (
               this.state.crntItems.map((item, idx, allItems) => (
-                <CollectionDataItem key={idx}
+                <CollectionDataItem key={item.uniqueId}
                                     fields={this.props.fields}
                                     index={idx}
                                     item={item}
@@ -232,7 +232,7 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
           <CollectionDataItem fields={this.props.fields}
                               index={null}
                               item={null}
-                              key={ this.state.crntItems ? this.state.crntItems.length + 1 : 1 }
+                              key={ this.state.crntItems ? this.state.crntItems.length + 1 : 1 } // This makes sure the empty row is rerendered from scratch when a new row is added / removed
                               sortingEnabled={this.props.enableSorting}
                               totalItems={null}
                               fAddItem={this.addItem}

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -232,7 +232,6 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
           <CollectionDataItem fields={this.props.fields}
                               index={null}
                               item={null}
-                              key={ this.state.crntItems ? this.state.crntItems.length + 1 : 1 } // This makes sure the empty row is rerendered from scratch when a new row is added / removed
                               sortingEnabled={this.props.enableSorting}
                               totalItems={null}
                               fAddItem={this.addItem}

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -232,6 +232,7 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
           <CollectionDataItem fields={this.props.fields}
                               index={null}
                               item={null}
+                              key={ this.state.crntItems ? this.state.crntItems.length + 1 : 1 }
                               sortingEnabled={this.props.enableSorting}
                               totalItems={null}
                               fAddItem={this.addItem}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | #135 

### What's in this Pull Request?

Fixed 3 different issues : 

#### First issue

The first issue occurs when you have a custom field and you remove a row in the middle of multiple rows. All of a sudden the row following the deleted row (the one that was right after it) gets its custom field value replaced by the one that was set on the row that just got deleted. Note that this problem does not happen with the provided example because it isn't a controlled component (which uses the state to set the selected item for example), but this issue will occur with any custom field rendering a **controlled** component.

This is because as explained [here ](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318), assigning keys to components using an index can cause lots of problems and this is exactly what this snippet from the **CollectionDataViewser.tsx** does :

```jsx
{
    (this.state.crntItems && this.state.crntItems.length > 0) && (
      this.state.crntItems.map((item, idx, allItems) => (
                <CollectionDataItem key={idx}
                                    fields={this.props.fields}
                                    index={idx}
                                    item={item}
                                    [...] />
      ))
    )
}
```

This causes React to get mixed up in the different states later on. So in order to correctly create a **unique** but **permanent** key for the **CollectionDataItem** components, I modified it's constructor in order to add a **uniqueId** property that gets filled with a unique GUID when the "dummy/empty" row gets initialized :

```typescript
constructor(props: ICollectionDataItemProps) {
    super(props);

    // Create an empty item with all properties
    let emptyItem = this.generateEmptyItem();
    
    [...]
}

  
private generateEmptyItem(): any {
    // Create an empty item with all properties
    let emptyItem:any = {};
    emptyItem.uniqueId = uuid();
    
    for (const field of this.props.fields) {
        // Assign default value or null to the emptyItem
        emptyItem[field.id] = field.defaultValue || null;
    }
    return emptyItem;
}
```

I also modified the **addRow** method in order to create a new **uniqueId** whenever we insert the current row and need to reset the "dummy/empty" row :

```typescript
private addRow = () => {
    if (this.props.fAddItem) {
        [...]

        // Clear all field values
        let emptyItem = this.generateEmptyItem();
        this.setState({
          crntItem: {...emptyItem}
        });
      }
    }
  }
```
 
This allows the **CollectionDataViewer.tsx** class to use this later on when it's time to specify keys for the components :

```jsx
{
            (this.state.crntItems && this.state.crntItems.length > 0) && (
              this.state.crntItems.map((item, idx, allItems) => (
                <CollectionDataItem key={item.uniqueId}
                                    fields={this.props.fields}
                                    index={idx}
                                    item={item}
                                    [...] />
              ))
            )
          }
```

This way each row/component will always have its own uniqueId/key from the moment it's created, and that uniqueId/key will remain the same no matter how you sort/move/delete rows, preventing React to get confused.


#### Second issue

As described in issue #135, there was a bug where the dummy "empty row" (which needs to be reseted after a new row insertion) would keep its value for custom field types that are rendering a **controlled** component. The code which is normally responsible for clearing all the field values in order to "reset" the "dummy/empty" row is the following :

```typescript
private addRow = () => {
    if (this.props.fAddItem) {
        [...]

        // Clear all field values
        let emptyItem = this.generateEmptyItem();
        this.setState({
          crntItem: {...emptyItem}
        });
      }
    }
  }
```

However, this is not a code issue, but most likely caused by the fact that a **controlled** component rendered in the **onCustomRender()** function uses its **state** to define its value, which means even though we try to rerender the component with a **null** value property, the component will ignore the new prop and use its state value instead.

So in order for the "dummy/empty" row to update it's custom field's component state (when fields need to be cleared), I needed a way to tell the **onCustomRender()** function that we are now dealing with a brand new row which needs the component to rerender from scratch. For this I simply updated the **ICustomCollectionField.ts** interface and modified the **onCustomRender()** signature with the following :

```typescript
onCustomRender?: (field: ICustomCollectionField, value: any, onUpdate: (fieldId: string, value: any) => void, rowUniqueId: string) => JSX.Element;
```

By adding the row/item **uniqueId** (created to fix issue #1) to the function's signature, the user can now modify the **componentDidUpdate** of his controlled component and specify his own logic that will rerender his component from scratch :

```typescript
public componentDidUpdate(prevProps: IAsyncDropdownProps, prevState: IAsyncDropdownState): void {
    if (this.props.rowUniqueId !== prevProps.rowUniqueId) {
        this.setState({
            selectedKey: null
        });
    }
}
```

That way when the "dummy/empty" row needs to be reset and have its field values cleared, its **uniqueId** will get regenerated (as shown in fix #1), the **onCustomRender** function will be called with the newly generated row's unique Id specified in the **rowUniqueId** parameter, and from that point it is up to the user to make sure the component rerenders if the uniqueId is different from the last one 👍 


#### Third issue

The last issue was a simply display bug occurring with dropdown fields on IE (and on Chrome when the dropdown had no options). The alignment would get all mixed and I added a simple line in the CSS to fix it.










