### PR TITLE
Property field color picker is hidden property support

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldColorPicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldColorPicker.md
@@ -36,6 +36,7 @@ PropertyFieldColorPicker('color', {
   onPropertyChange: this.onPropertyPaneFieldChanged,
   properties: this.properties,
   disabled: false,
+  isHidden: false,
   alphaSliderHidden: false,
   style: PropertyFieldColorPickerStyle.Full,
   iconName: 'Precipitation',
@@ -51,6 +52,7 @@ The `PropertyFieldColorPicker` control can be configured with the following prop
 | ---- | ---- | ---- | ---- |
 | label | string | yes | Property field label displayed on top. |
 | disabled | boolean | no | Specify if the control needs to be disabled. |
+| isHidden | boolean | no | Specify if the control needs to be hidden. |
 | selectedColor | string or IColor | no | The CSS-compatible string or an IColor object to describe the initial color |
 | alphaSliderHidden | boolean | no | When true, the alpha slider control is hidden |
 | style | PropertyFieldColorPickerStyle | no | Determines how the control is displayed (defaults to inline) |

--- a/src/propertyFields/colorPicker/IPropertyFieldColorPicker.ts
+++ b/src/propertyFields/colorPicker/IPropertyFieldColorPicker.ts
@@ -36,10 +36,15 @@ export interface IPropertyFieldColorPickerProps {
 	 */
 	alphaSliderHidden?: boolean;
 
-	 /**
-	 * Whether the property pane field is enabled or not.
-	 */
+	/**
+	* Whether the property pane field is enabled or not.
+	*/
 	disabled?: boolean;
+
+	/**
+	* Whether the property pane field is hidden or not.
+	*/
+	isHidden?: boolean;
 
 	/**
 	 * An UNIQUE key indicates the identity of this control

--- a/src/propertyFields/colorPicker/IPropertyFieldColorPickerHost.ts
+++ b/src/propertyFields/colorPicker/IPropertyFieldColorPickerHost.ts
@@ -7,6 +7,7 @@ export interface IPropertyFieldColorPickerHostProps {
 	label: string;
 	alphaSliderHidden: boolean;
 	disabled: boolean;
+	isHidden: boolean;
 	selectedColor: string;
 	style: PropertyFieldColorPickerStyle;
 	iconName: string;

--- a/src/propertyFields/colorPicker/PropertyFieldColorPicker.ts
+++ b/src/propertyFields/colorPicker/PropertyFieldColorPicker.ts
@@ -4,15 +4,15 @@ import * as React from 'react';
 import * as ReactDom from 'react-dom';
 
 import {
-    IPropertyFieldColorPickerProps,
-    IPropertyFieldColorPickerPropsInternal,
-    PropertyFieldColorPickerStyle,
+	IPropertyFieldColorPickerProps,
+	IPropertyFieldColorPickerPropsInternal,
+	PropertyFieldColorPickerStyle,
 } from './IPropertyFieldColorPicker';
 import { IPropertyFieldColorPickerHostProps } from './IPropertyFieldColorPickerHost';
 import PropertyFieldColorPickerHost from './PropertyFieldColorPickerHost';
 
 class PropertyFieldColorPickerBuilder implements IPropertyPaneField<IPropertyFieldColorPickerProps> {
-	
+
 	//Properties defined by IPropertyPaneField
 	public type: PropertyPaneFieldType = PropertyPaneFieldType.Custom;
 	public targetProperty: string;
@@ -30,6 +30,7 @@ class PropertyFieldColorPickerBuilder implements IPropertyPaneField<IPropertyFie
 			onPropertyChange: _properties.onPropertyChange,
 			selectedColor: _properties.selectedColor,
 			disabled: _properties.disabled,
+			isHidden: _properties.isHidden,
 			alphaSliderHidden: _properties.alphaSliderHidden,
 			properties: _properties.properties,
 			style: _properties.style,
@@ -68,6 +69,7 @@ class PropertyFieldColorPickerBuilder implements IPropertyPaneField<IPropertyFie
 			label: this.properties.label,
 			alphaSliderHidden: this.properties.alphaSliderHidden,
 			disabled: this.properties.disabled,
+			isHidden: this.properties.isHidden,
 			selectedColor: this.color,
 			style: this.properties.style || PropertyFieldColorPickerStyle.Inline,
 			iconName: this.properties.iconName || 'Color',

--- a/src/propertyFields/colorPicker/PropertyFieldColorPickerHost.module.scss
+++ b/src/propertyFields/colorPicker/PropertyFieldColorPickerHost.module.scss
@@ -28,3 +28,7 @@
 		margin: 0;
 	}
 }
+
+.hidden{
+	display: none;
+}

--- a/src/propertyFields/colorPicker/PropertyFieldColorPickerHost.tsx
+++ b/src/propertyFields/colorPicker/PropertyFieldColorPickerHost.tsx
@@ -14,11 +14,11 @@ import * as telemetry from '../../common/telemetry';
 export default class PropertyFieldColorPickerHost extends React.Component<IPropertyFieldColorPickerHostProps, IPropertyFieldColorPickerHostState> {
 
 	constructor(props: IPropertyFieldColorPickerHostProps, state: IPropertyFieldColorPickerHostState) {
-    super(props);
+		super(props);
 
-    telemetry.track('PropertyFieldColorPicker', {
-      disabled: props.disabled
-    });
+		telemetry.track('PropertyFieldColorPicker', {
+			disabled: props.disabled
+		  });
 
 		this.state = {
 			errorMessage: undefined,
@@ -29,8 +29,9 @@ export default class PropertyFieldColorPickerHost extends React.Component<IPrope
 	}
 
 	public render(): JSX.Element {
+		let colorPickerClassName = styles.pfColorPicker + (this.props.isHidden === true ? (' ' + styles.hidden): '' );
 		return (
-			<div className={styles.pfColorPicker}>
+			<div className={colorPickerClassName}>
 				{this.props.label && <Label>{this.props.label}</Label>}
 				{this.props.style === PropertyFieldColorPickerStyle.Inline &&
 					<table className={styles.cpInlineTable}>
@@ -47,7 +48,7 @@ export default class PropertyFieldColorPickerHost extends React.Component<IPrope
 									}
 									{!this.state.inlinePickerShowing &&
 										<div className="ms-slideUpIn20 ms-borderColor-neutralDark"
-										 style={{backgroundColor:this.props.selectedColor, border:"1px solid"}}>&nbsp;</div>
+											style={{backgroundColor:this.props.selectedColor, border:"1px solid"}}>&nbsp;</div>
 									}
 								</td>
 								<td className={styles.cpInlineRow}>
@@ -88,5 +89,5 @@ export default class PropertyFieldColorPickerHost extends React.Component<IPrope
 			inlinePickerShowing: !this.state.inlinePickerShowing
 		});
 	}
-
+	
 }

--- a/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
+++ b/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
@@ -14,6 +14,7 @@ export interface IPropertyControlsTestWebPartProps {
   terms: IPickerTerms;
   datetime: IDateTimeFieldValue;
   fileUrl: string;
+  isColorFieldVisible:boolean;
   color: string;
   colorObj: IColor;
   spinValue: number;

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -6,7 +6,8 @@ import { Version } from '@microsoft/sp-core-library';
 import {
   BaseClientSideWebPart,
   IPropertyPaneConfiguration,
-  PropertyPaneTextField
+  PropertyPaneTextField,
+  PropertyPaneToggle,
 } from '@microsoft/sp-webpart-base';
 import { PropertyFieldCodeEditor,PropertyFieldCodeEditorLanguages } from '../../PropertyFieldCodeEditor';
 import * as strings from 'PropertyControlsTestWebPartStrings';
@@ -370,6 +371,10 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   deferredValidationTime: 0,
                   key: 'dateTimeFieldId'
                 }),
+                PropertyPaneToggle("isColorFieldVisible", {
+                  label: "Color Field Visible",
+                  checked: true
+                }),
                 PropertyFieldColorPicker('color', {
                   label: 'Color',
                   selectedColor: this.properties.color,
@@ -379,6 +384,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   //alphaSliderHidden: true,
                   //style: PropertyFieldColorPickerStyle.Full,
                   //iconName: 'Precipitation',
+                  isHidden: this.properties.isColorFieldVisible===false,
                   key: 'colorFieldId'
                 }),
                 PropertyFieldColorPicker('colorObj', {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [ Add isHidden property for PropertyFieldColorPicker]
| Related issues?  | #138 

#### What's in this Pull Request?
1. Add isHidden property for PropertyFieldColorPicker.
2. Add toggle button in test web part's configuration pane to control color field's visibility(For Testing purpose only)
3. Update PropertyFieldColorPicker guide.

- Sample:
PropertyFieldColorPicker('color', {
                  label: 'Color',
                  selectedColor: this.properties.color,
                  onPropertyChange: this.onPropertyPaneFieldChanged,
                  properties: this.properties,
                  disabled: false,
                  alphaSliderHidden: true,
                  **isHidden: true,**
                  key: 'colorFieldId'
                }),




