### PR TITLE
Prepare v1.14.1

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,7 +6,8 @@
         "new": [],
         "enhancements": [],
         "fixes": [
-          "`TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)"
+          "`TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)",
+          "`EnterpriseTermPicker`: Terms are sorted incorrectly under the wrong parent [#156](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/156)"
         ]
       },
       "contributions": []

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -19,7 +19,8 @@
           "`PropertyFieldTermPicker`: fix sort order with lowercased terms [#133](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/133)",
           "`PropertyFieldCollectionData`: Bug with onCustomRender() [#135](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/135)",
           "`PropertyFieldCollectionData`: Fixed bug with dropdown rendering in IE [#136](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/136)",
-          "`PropertyFieldNumber`: Min/max number check fix + localization label fixes [#141](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/141)"
+          "`PropertyFieldNumber`: Min/max number check fix + localization label fixes [#141](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/141)",
+          "`PropertyFieldTermPicker`: Fix layout issues in IE11 [#143](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/143)"
         ]
       },
       "contributions": [

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,17 @@
 {
   "versions": [
     {
+      "version": "1.14.1",
+      "changes": {
+        "new": [],
+        "enhancements": [],
+        "fixes": [
+          "`TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)"
+        ]
+      },
+      "contributions": []
+    },
+    {
       "version": "1.14.0",
       "changes": {
         "new": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `PropertyFieldCollectionData`: Bug with onCustomRender() [#135](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/135)
 - `PropertyFieldCollectionData`: Fixed bug with dropdown rendering in IE [#136](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/136)
 - `PropertyFieldNumber`: Min/max number check fix + localization label fixes [#141](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/141)
+- `PropertyFieldTermPicker`: Fix layout issues in IE11 [#143](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/143)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)
+- `EnterpriseTermPicker`: Terms are sorted incorrectly under the wrong parent [#156](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/156)
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.14.1
+
+### Fixes
+
+- `TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)
+
 ## 1.14.0
 
 ### New control(s)

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -22,6 +22,7 @@
 - `PropertyFieldCollectionData`: Bug with onCustomRender() [#135](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/135)
 - `PropertyFieldCollectionData`: Fixed bug with dropdown rendering in IE [#136](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/136)
 - `PropertyFieldNumber`: Min/max number check fix + localization label fixes [#141](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/141)
+- `PropertyFieldTermPicker`: Fix layout issues in IE11 [#143](https://github.com/SharePoint/sp-dev-fx-property-controls/pull/143)
 
 ### Contributors
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)
+- `EnterpriseTermPicker`: Terms are sorted incorrectly under the wrong parent [#156](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/156)
 
 ## 1.14.0
 

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.14.1
+
+### Fixes
+
+- `TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)
+
 ## 1.14.0
 
 ### New control(s)

--- a/docs/documentation/docs/controls/PropertyPaneWebPartInformation.md
+++ b/docs/documentation/docs/controls/PropertyPaneWebPartInformation.md
@@ -13,7 +13,7 @@ This control allows you to specify a description, a 'read more' link, and an opt
 2. Import the following modules to your component: 
 
 ```TypeScript
-import { PropertyWebPartInformation } from '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation';
+import { PropertyPaneWebPartInformation } from '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation';
 ```
 
 3. Create a new property for your web part, for example:

--- a/docs/documentation/mkdocs.yml
+++ b/docs/documentation/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - PropertyFieldCollectionData: 'controls/PropertyFieldCollectionData.md'
     - PropertyFieldColorPicker: 'controls/PropertyFieldColorPicker.md'
     - PropertyFieldDateTimePicker: 'controls/PropertyFieldDateTimePicker.md'
+    - PropertyFieldEnterpriseTermPicker: 'controls/PropertyFieldEnterpriseTermPicker.md'
     - PropertyFieldListPicker: 'controls/PropertyFieldListPicker.md'
     - PropertyFieldMultiSelect: 'controls/PropertyFieldMultiSelect.md'
     - PropertyFieldNumber: 'controls/PropertyFieldNumber.md'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/spfx-property-controls",
   "description": "Reusable property pane controls for SharePoint Framework solutions",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "1.14.0";
+export const version: string = "1.14.1";

--- a/src/services/PnPTermStorePickerService.ts
+++ b/src/services/PnPTermStorePickerService.ts
@@ -194,8 +194,7 @@ export default class PnPTermStorePickerService implements ISPTermStorePickerServ
         }
         await this._ensureTermStores();
         const pnpTermStores = this._pnpTermStores;
-        for (let i = 0, len = pnpTermStores.length; i < len; i++) {
-            const pnpTermStore = pnpTermStores[i];
+        for (const pnpTermStore of pnpTermStores) {
             const termsResult: any = await this._tryGetAllTerms(pnpTermStore, termSet).catch((error) => { }); // .catch part is needed to proceed if there was a rejected promise
             if (!termsResult) { // terms variable will be undefined if the Promise has been rejected. Otherwise it will contain an array
                 continue;
@@ -226,7 +225,7 @@ export default class PnPTermStorePickerService implements ISPTermStorePickerServ
                 await labelsBatch.execute();
             }
 
-            return resultTerms;
+            return TermStorePickerServiceHelper.sortTerms(resultTerms);
         }
 
     }
@@ -397,12 +396,12 @@ export default class PnPTermStorePickerService implements ISPTermStorePickerServ
                 pnpTerm.termSet.group.inBatch(batch).usingCaching().get().then(pnpTermGroup => {
                      pickerTerm.termGroup = TermStorePickerServiceHelper.cleanGuid(pnpTermGroup.Id);
                  });
- 
+
                  pnpTerm.termSet.inBatch(batch).usingCaching().get().then(pnpTermSet => {
                      pickerTerm.termSet = TermStorePickerServiceHelper.cleanGuid(pnpTermSet.Id);
                      pickerTerm.termSetName = pnpTermSet.Name;
                  });
- 
+
                  if (this.props.includeLabels) {
                      pnpTerm.labels.inBatch(batch).usingCaching().get().then(labels => {
                          pickerTerm.labels = labels.map(label => label.Value);

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -172,8 +172,8 @@ export default class SPTermStorePickerService implements ISPTermStorePickerServi
             });
             // Check if the term set was not empty
             if (terms.length > 0) {
-              // Sort the terms by PathOfTerm
-              return terms.sort(TermStorePickerServiceHelper.sortTerms);
+              // Sort the terms by PathOfTerm and their depth
+              return TermStorePickerServiceHelper.sortTerms(terms);
             }
           }
           return null;

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -286,7 +286,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   onGetErrorMessage: null,
                   deferredValidationTime: 0,
                   //limitByGroupNameOrID: 'Test',
-                  //limitByTermsetNameOrID: 'ad54531f-506e-4cc6-af4f-71157f6f3280',
+                  limitByTermsetNameOrID: '7276c08b-58c1-4fcd-812e-f21299a06b85',
                   isTermSetSelectable: true,
                   key: 'termSetsPickerFieldId',
                   hideTermStoreName: true


### PR DESCRIPTION
### Fixes

- `TaxonomyPicker`: Terms are sorted incorrectly under the wrong parent [#153](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/153)
- `EnterpriseTermPicker`: Terms are sorted incorrectly under the wrong parent [#156](https://github.com/SharePoint/sp-dev-fx-property-controls/issues/156)