### PR TITLE
#77 and space between date and time parts

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldDateTimePicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldDateTimePicker.md
@@ -48,7 +48,8 @@ PropertyFieldDateTimePicker('datetime', {
   properties: this.properties,
   onGetErrorMessage: null,
   deferredValidationTime: 0,
-  key: 'dateTimeFieldId'
+  key: 'dateTimeFieldId',
+  showLabels: false
 })
 ```
 
@@ -69,6 +70,7 @@ The `PropertyFieldDateTimePicker` control can be configured with the following p
 | key | string | yes | An unique key that indicates the identity of this control. |
 | onGetErrorMessage | function | no | The method is used to get the validation error message and determine whether the input value is valid or not. See [this documentation](https://dev.office.com/sharepoint/docs/spfx/web-parts/guidance/validate-web-part-property-values) to learn how to use it. |
 | deferredValidationTime | number | no | Control will start to validate after users stop typing for `deferredValidationTime` milliseconds. Default value is 200. |
+| showLabels | boolean | no | Specify if labels in front of Date and Time parts should be rendered. By default this is set to `true` |
 
 Interface `IDateTimeFieldValue`
 

--- a/src/propertyFields/dateTimePicker/IPropertyFieldDateTimePicker.ts
+++ b/src/propertyFields/dateTimePicker/IPropertyFieldDateTimePicker.ts
@@ -105,6 +105,11 @@ export interface IPropertyFieldDateTimePickerProps {
    * Default value is 200.
    */
   deferredValidationTime?: number;
+
+  /**
+   * Specify if labels in front of date and time parts should be rendered. True by default
+   */
+  showLabels?: boolean;
 }
 
 /**

--- a/src/propertyFields/dateTimePicker/PropertyFieldDateTimePicker.ts
+++ b/src/propertyFields/dateTimePicker/PropertyFieldDateTimePicker.ts
@@ -32,6 +32,7 @@ class PropertyFieldDateTimePickerBuilder implements IPropertyPaneField<IProperty
   private key: string;
   private onGetErrorMessage: (value: string) => string | Promise<string>;
   private deferredValidationTime: number = 200;
+  private showLabels: boolean = true;
 
   /**
    * Constructor
@@ -75,6 +76,8 @@ class PropertyFieldDateTimePickerBuilder implements IPropertyPaneField<IProperty
     } else {
       this.firstDayOfWeek = DayOfWeek.Sunday;
     }
+
+    this.showLabels = _properties.showLabels;
   }
 
   /**
@@ -98,7 +101,8 @@ class PropertyFieldDateTimePickerBuilder implements IPropertyPaneField<IProperty
       properties: this.customProperties,
       key: this.key,
       onGetErrorMessage: this.onGetErrorMessage,
-      deferredValidationTime: this.deferredValidationTime
+      deferredValidationTime: this.deferredValidationTime,
+      showLabels: this.showLabels
     });
     // Calls the REACT content generator
     ReactDom.render(element, elem);

--- a/src/propertyFields/dateTimePicker/PropertyFieldDateTimePickerHost.module.scss
+++ b/src/propertyFields/dateTimePicker/PropertyFieldDateTimePickerHost.module.scss
@@ -21,4 +21,8 @@
   .fieldLabel {
     margin-right: 4px;
   }
+
+  .spacerRow {
+    height: 5px;
+  }
 }

--- a/src/propertyFields/dateTimePicker/PropertyFieldDateTimePickerHost.tsx
+++ b/src/propertyFields/dateTimePicker/PropertyFieldDateTimePickerHost.tsx
@@ -75,6 +75,11 @@ class DatePickerStrings implements IDatePickerStrings {
  * Renders the controls for PropertyFieldDateTimePicker component
  */
 export default class PropertyFieldDateTimePickerHost extends React.Component<IPropertyFieldDateTimePickerHostProps, IPropertyFieldDateTimePickerHostState> {
+
+  public static defaultProps = {
+    showLabels: true
+  };
+
   private _latestValidateValue: string;
   private async: Async;
   private delayedValidate: (value: IDateTimeFieldValue) => void;
@@ -282,58 +287,67 @@ export default class PropertyFieldDateTimePickerHost extends React.Component<IPr
     // Defines the DatePicker control labels
     const dateStrings: DatePickerStrings = new DatePickerStrings();
 
+    const {
+      showLabels,
+      disabled,
+      timeConvention,
+      dateConvention,
+      label
+    } = this.props;
+
     // Check if the time element needs to be rendered
     let timeElm: JSX.Element = <tr />;
-    if (this.props.dateConvention === DateConvention.DateTime) {
-      timeElm = (<tr>
-        <td className={styles.labelCell}>
-          <Label className={styles.fieldLabel}>{strings.DateTimePickerTime}</Label>
-        </td>
-        <td>
-          <table cellPadding='0' cellSpacing='0'>
-            <tbody>
-              <tr>
-                <td>
-                  <HoursComponent
-                    disabled={this.props.disabled}
-                    timeConvention={this.props.timeConvention}
-                    value={this.state.hours}
-                    onChange={this._dropdownHoursChanged} />
-                </td>
-                <td className={styles.seperator}><Label>:</Label></td>
-                <td>
-                  <MinutesComponent
-                    disabled={this.props.disabled}
-                    value={this.state.minutes}
-                    onChange={this._dropdownMinutesChanged} />
-                </td>
-                <td className={styles.seperator}><Label>:</Label></td>
-                <td>
-                  <SecondsComponent
-                    disabled={this.props.disabled}
-                    value={this.state.seconds}
-                    onChange={this._dropdownSecondsChanged} />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </td>
-      </tr>);
+    if (dateConvention === DateConvention.DateTime) {
+      timeElm = (
+        <tr>
+          {showLabels && <td className={styles.labelCell}>
+            <Label className={styles.fieldLabel}>{strings.DateTimePickerTime}</Label>
+          </td>}
+          <td>
+            <table cellPadding='0' cellSpacing='0'>
+              <tbody>
+                <tr>
+                  <td>
+                    <HoursComponent
+                      disabled={disabled}
+                      timeConvention={timeConvention}
+                      value={this.state.hours}
+                      onChange={this._dropdownHoursChanged} />
+                  </td>
+                  <td className={styles.seperator}><Label>:</Label></td>
+                  <td>
+                    <MinutesComponent
+                      disabled={disabled}
+                      value={this.state.minutes}
+                      onChange={this._dropdownMinutesChanged} />
+                  </td>
+                  <td className={styles.seperator}><Label>:</Label></td>
+                  <td>
+                    <SecondsComponent
+                      disabled={disabled}
+                      value={this.state.seconds}
+                      onChange={this._dropdownSecondsChanged} />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>);
     }
 
     // Renders content
     return (
       <div className={styles.propertyFieldDateTimePicker}>
-        {this.props.label && <Label>{this.props.label}</Label>}
+        {label && <Label>{label}</Label>}
         <table cellPadding='0' cellSpacing='0'>
           <tbody>
             <tr>
-              <td className={styles.labelCell}>
+              {showLabels && <td className={styles.labelCell}>
                 <Label className={styles.fieldLabel}>{strings.DateTimePickerDate}</Label>
-              </td>
+              </td>}
               <td>
                 <DatePicker
-                  disabled={this.props.disabled}
+                  disabled={disabled}
                   value={this.state.day}
                   strings={dateStrings}
                   isMonthPickerVisible={true}
@@ -342,7 +356,10 @@ export default class PropertyFieldDateTimePickerHost extends React.Component<IPr
                   firstDayOfWeek={this.props.firstDayOfWeek} />
               </td>
             </tr>
-
+            {!!timeElm &&
+              <tr>
+                <td className={styles.spacerRow} colSpan={showLabels ? 2 : 1}></td>
+              </tr>}
             {timeElm}
           </tbody>
         </table>

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -376,7 +376,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   properties: this.properties,
                   onGetErrorMessage: null,
                   deferredValidationTime: 0,
-                  key: 'dateTimeFieldId'
+                  key: 'dateTimeFieldId',
+                  showLabels: false
                 }),
                 PropertyPaneToggle("isColorFieldVisible", {
                   label: "Color Field Visible",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #77 

#### What's in this Pull Request?

1. `showLabels` property is added to control visibility of the labels for Date and Time parts
2. Space is added between Date and Time parts