### PR TITLE
Add filter and list items retrieved logic

### DIFF
--- a/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
@@ -1,5 +1,6 @@
 import { IWebPartContext, IPropertyPaneCustomFieldProps } from '@microsoft/sp-webpart-base';
-import { ISPList, ISPLists } from '../../../lib';
+import { ISPList } from './IPropertyFieldListPickerHost';
+
 
 /**
  * Enum for specifying how the lists should be sorted

--- a/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/IPropertyFieldListPicker.ts
@@ -1,4 +1,5 @@
 import { IWebPartContext, IPropertyPaneCustomFieldProps } from '@microsoft/sp-webpart-base';
+import { ISPList, ISPLists } from '../../../lib';
 
 /**
  * Enum for specifying how the lists should be sorted
@@ -98,6 +99,14 @@ export interface IPropertyFieldListPickerProps {
    * Defines list titles which should be excluded from the list picker control
    */
   listsToExclude?: string[];
+  /**
+   * Filter list from Odata query (takes precendents over Hidden and BaseTemplate Filters)
+   */
+  filter?: string;
+  /** 
+   * Callback that is called before the dropdown is populated
+   */
+  onListsRetrieved?: (lists: ISPList[]) => PromiseLike<ISPList[]> | ISPList[];
 }
 
 /**
@@ -125,4 +134,6 @@ export interface IPropertyFieldListPickerPropsInternal extends IPropertyFieldLis
   onGetErrorMessage?: (value: string | string[]) => string | Promise<string>;
   deferredValidationTime?: number;
   listsToExclude?: string[];
+  filter?: string;
+  onListsRetrieved?: (lists: ISPList[]) => PromiseLike<ISPList[]> | ISPList[];
 }

--- a/src/propertyFields/listPicker/PropertyFieldListPicker.ts
+++ b/src/propertyFields/listPicker/PropertyFieldListPicker.ts
@@ -7,7 +7,7 @@ import {
 } from '@microsoft/sp-webpart-base';
 import PropertyFieldListPickerHost from './PropertyFieldListPickerHost';
 import PropertyFieldListMultiPickerHost from './PropertyFieldListMultiPickerHost';
-import { IPropertyFieldListPickerHostProps } from './IPropertyFieldListPickerHost';
+import { IPropertyFieldListPickerHostProps, ISPList } from './IPropertyFieldListPickerHost';
 import { IPropertyFieldListMultiPickerHostProps } from './IPropertyFieldListMultiPickerHost';
 import { PropertyFieldListPickerOrderBy, IPropertyFieldListPickerProps, IPropertyFieldListPickerPropsInternal } from './IPropertyFieldListPicker';
 
@@ -44,7 +44,8 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
   private deferredValidationTime: number = 200;
   private renderWebPart: () => void;
   private disableReactivePropertyChanges: boolean = false;
-
+  private filter: string;
+  private onListsRetrieved?: (lists: ISPList[]) => PromiseLike<ISPList[]> | ISPList[];
   /**
    * Constructor method
    */
@@ -71,7 +72,9 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
     this.key = _properties.key;
     this.onGetErrorMessage = _properties.onGetErrorMessage;
     this.listsToExclude = _properties.listsToExclude;
-
+    this.filter = _properties.filter;
+    this.onListsRetrieved = _properties.onListsRetrieved;
+    
     if (_properties.disabled === true) {
       this.disabled = _properties.disabled;
     }
@@ -102,7 +105,9 @@ class PropertyFieldListPickerBuilder implements IPropertyPaneField<IPropertyFiel
       disabled: this.disabled,
       onGetErrorMessage: this.onGetErrorMessage,
       deferredValidationTime: this.deferredValidationTime,
-      listsToExclude: this.listsToExclude
+      listsToExclude: this.listsToExclude,
+      filter: this.filter,
+      onListsRetrieved: this.onListsRetrieved
     };
 
     // Check if the multi or single select component has to get loaded
@@ -163,7 +168,9 @@ export function PropertyFieldListPicker(targetProperty: string, properties: IPro
     disabled: properties.disabled,
     onGetErrorMessage: properties.onGetErrorMessage,
     deferredValidationTime: properties.deferredValidationTime,
-    listsToExclude: properties.listsToExclude
+    listsToExclude: properties.listsToExclude,
+    filter: properties.filter,
+    onListsRetrieved: properties.onListsRetrieved
   };
   //Calls the PropertyFieldListPicker builder object
   //This object will simulate a PropertyFieldCustom to manage his rendering process

--- a/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
+++ b/src/webparts/propertyControlsTest/IPropertyControlsTestWebPartProps.ts
@@ -11,6 +11,8 @@ export interface IPropertyControlsTestWebPartProps {
   people: IPropertyFieldGroupOrPerson[];
   singleList: string | string[];
   multiList: string | string[];
+  singleListFiltered: string;
+  multiListFiltered: string[];
   terms: IPickerTerms;
   datetime: IDateTimeFieldValue;
   fileUrl: string;

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -39,6 +39,7 @@ import { PropertyFieldSwatchColorPicker, PropertyFieldSwatchColorPickerStyle } f
 import { PropertyPaneWebPartInformation } from '../../propertyFields/webPartInformation';
 import { PropertyPanePropertyEditor } from '../../propertyFields/propertyEditor/PropertyPanePropertyEditor';
 import { PropertyFieldEnterpriseTermPicker } from '../../propertyFields/termPicker/PropertyFieldEnterpriseTermPicker';
+import { ISPList } from '../../propertyFields/listPicker';
 
 /**
  * Web part that can be used to test out the various property controls
@@ -55,7 +56,9 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
         multiSelect: this.properties.multiSelect || [],
         people: this.properties.people || [],
         list: this.properties.singleList as string || "",
+        listFiltered: this.properties.singleListFiltered || "",
         multiList: this.properties.multiList as string[] || [],
+        multiListFiltered: this.properties.multiListFiltered || [],
         terms: this.properties.terms || [],
         datetime: this.properties.datetime || { value: null, displayValue: null },
         color: this.properties.color,
@@ -349,7 +352,31 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   deferredValidationTime: 0,
                   key: 'listPickerFieldId',
                   webAbsoluteUrl: this.properties.siteUrl || this.context.pageContext.web.absoluteUrl,
-                  listsToExclude: ["cdn"]
+                  listsToExclude: ["cdn"],
+                }),
+                PropertyFieldListPicker('singleListFiltered', {
+                  label: 'Select a list (Filtered)',
+                  selectedList: this.properties.singleListFiltered,
+                  includeHidden: false,
+                  //baseTemplate: 109,
+                  orderBy: PropertyFieldListPickerOrderBy.Title,
+                  // multiSelect: false,
+                  disabled: false,
+                  onPropertyChange: this.onPropertyPaneFieldChanged.bind(this),
+                  properties: this.properties,
+                  context: this.context,
+                  onGetErrorMessage: (value: string) => {
+                    return value;
+                  },
+                  deferredValidationTime: 0,
+                  key: 'listPickerFieldId',
+                  webAbsoluteUrl: this.properties.siteUrl || this.context.pageContext.web.absoluteUrl,
+                  listsToExclude: ["cdn"],
+                  filter: "ItemCount gt 0",
+                  onListsRetrieved: (lists: ISPList[]) => {
+                    console.log("Lists", lists);
+                    return lists;
+                  }
                 }),
                 PropertyFieldListPicker('multiList', {
                   label: 'Select multiple lists',
@@ -369,6 +396,31 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   deferredValidationTime: 0,
                   key: 'multiListPickerFieldId',
                   webAbsoluteUrl: this.properties.siteUrl || this.context.pageContext.web.absoluteUrl,
+                  listsToExclude: ["cdn"]
+                }),
+                PropertyFieldListPicker('multiListFiltered', {
+                  label: 'Select multiple lists (Filtered)',
+                  selectedList: this.properties.multiListFiltered,
+                  includeHidden: false,
+                  //baseTemplate: 109,
+                  orderBy: PropertyFieldListPickerOrderBy.Title,
+                  multiSelect: true,
+                  showSelectAll: true,
+                  selectAllInList: false,
+                  selectAllInListLabel: 'Select all',
+                  disabled: false,
+                  onPropertyChange: this.onPropertyPaneFieldChanged.bind(this),
+                  properties: this.properties,
+                  context: this.context,
+                  onGetErrorMessage: null,
+                  deferredValidationTime: 0,
+                  key: 'multiListPickerFieldId',
+                  webAbsoluteUrl: this.properties.siteUrl || this.context.pageContext.web.absoluteUrl,
+                  filter: "ItemCount gt 0",
+                  onListsRetrieved: (lists: ISPList[]) => {
+                    console.log("Lists", lists);
+                    return Promise.resolve(lists);
+                  },
                   listsToExclude: ["cdn"]
                 }),
                 PropertyFieldDateTimePicker('datetime', {

--- a/src/webparts/propertyControlsTest/components/IPropertyControlsTestProps.ts
+++ b/src/webparts/propertyControlsTest/components/IPropertyControlsTestProps.ts
@@ -12,7 +12,9 @@ export interface IPropertyControlsTestProps {
   multiSelect: string[];
   people: IPropertyFieldGroupOrPerson[];
   list: string | string[];
+  listFiltered: string;
   multiList: string[];
+  multiListFiltered: string[];
   terms: IPickerTerms;
   datetime: IDateTimeFieldValue;
   color: string;

--- a/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
+++ b/src/webparts/propertyControlsTest/components/PropertyControlsTest.tsx
@@ -26,7 +26,9 @@ export default class PropertyControlsTest extends React.Component<IPropertyContr
               <div dangerouslySetInnerHTML={this.setHtml()} />
               </p>
               <p className="ms-font-m ms-fontColor-neutralDark">List: {this.props.list}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark">List Filtered: {this.props.listFiltered}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Multi List: {this.props.multiList.join(', ')}</p>
+              <p className="ms-font-m ms-fontColor-neutralDark">Multi Filtered: {this.props.multiListFiltered.join(', ')}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Term(s): {this.props.terms.map(t => t.name).join(', ')}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Date: {this.props.datetime.displayValue}</p>
               <p className="ms-font-m ms-fontColor-neutralDark">Color: <span className={styles.colorBox} style={{backgroundColor:this.props.color}}>&nbsp;</span>{this.props.color}</p>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [X]
| Related issues?  | fixes #184 

#### What's in this Pull Request?
This PR adds the ability for a developer to filter the list in the List Property Control. It add an OData filter to the properties and also adds an onListsRetrieved callback that will allow the dev to make additional manipulations to the list of lists.
