### PR TITLE
Add debounce property do PropertyFieldSliderWithCallout.

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldSliderWithCallout.md
+++ b/docs/documentation/docs/controls/PropertyFieldSliderWithCallout.md
@@ -42,7 +42,8 @@ PropertyFieldSliderWithCallout('sliderWithCalloutValue', {
   min: 0,
   step: 1,
   showValue: true,
-  value: this.properties.sliderWithCalloutValue
+  value: this.properties.sliderWithCalloutValue,
+  debounce: 1000
 })
 ```
 
@@ -56,6 +57,7 @@ The `PropertyFieldSliderWithCallout` control uses the same implementation as the
 | calloutWidth | number | no | Custom width for callout including borders. If value is 0, no width is applied. |
 | calloutTrigger | CalloutTriggers | no | Event to show the callout |
 | gapSpace | number | no | The gap between the callout and the target |
+| debounce | number | no | Time specified in miliseconds after which the onChanged handler is going to be called. |
 
 Enum `CalloutTriggers`
 

--- a/src/common/util/Util.ts
+++ b/src/common/util/Util.ts
@@ -1,0 +1,15 @@
+/**
+ * Debounce function
+ *
+ * @param fnc Function to execute
+ * @param time Time to wait until the function gets executed
+ */
+export const debounce = () => {
+  let timeout;
+
+  return (fnc: any, time: number) => {
+    const functionCall = (...args) => fnc.apply(this, args);
+    clearTimeout(timeout);
+    timeout = setTimeout(functionCall, time);
+  };
+};

--- a/src/common/util/index.ts
+++ b/src/common/util/index.ts
@@ -1,0 +1,1 @@
+export * from './Util';

--- a/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCallout.ts
+++ b/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCallout.ts
@@ -8,6 +8,7 @@ import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHead
 export interface IPropertyFieldSliderWithCalloutPropsInternal
     extends IPropertyPaneCustomFieldProps, IPropertyPaneSliderProps, IPropertyFieldHeaderCalloutProps {
         key: string;
+        debounce?: number;
     }
 
 /**
@@ -15,4 +16,5 @@ export interface IPropertyFieldSliderWithCalloutPropsInternal
  */
 export interface IPropertyFieldSliderWithCalloutProps extends IPropertyPaneSliderProps, IPropertyFieldHeaderCalloutProps {
     key: string;
+    debounce?: number;
 }

--- a/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCalloutHost.ts
+++ b/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCalloutHost.ts
@@ -5,4 +5,5 @@ import { ISliderProps } from 'office-ui-fabric-react/lib/components/Slider';
  * PropertyFieldSliderWithCalloutHost properties interface
  */
 export interface IPropertyFieldSliderWithCalloutHostProps extends ISliderProps, IPropertyFieldHeaderCalloutProps {
+  debounce?: number;
 }

--- a/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCallout.ts
+++ b/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCallout.ts
@@ -8,6 +8,7 @@ import {
 import PropertyFieldSliderWithCalloutHost from './PropertyFieldSliderWithCalloutHost';
 
 import {IPropertyFieldSliderWithCalloutPropsInternal, IPropertyFieldSliderWithCalloutProps} from './IPropertyFieldSliderWithCallout';
+import { debounce } from '../../common/util/Util';
 
 class PropertyFieldSliderWithCalloutBuilder implements IPropertyPaneField<IPropertyFieldSliderWithCalloutPropsInternal> {
     public targetProperty: string;
@@ -15,6 +16,7 @@ class PropertyFieldSliderWithCalloutBuilder implements IPropertyPaneField<IPrope
     public properties: IPropertyFieldSliderWithCalloutPropsInternal;
 
     private _onChangeCallback: (targetProperty?: string, newValue?: any) => void;
+    private _debounce: (fnc: any, timeout:number) => void = debounce();
 
     public constructor(_targetProperty: string, _properties: IPropertyFieldSliderWithCalloutPropsInternal) {
         this.targetProperty = _targetProperty;
@@ -45,7 +47,10 @@ class PropertyFieldSliderWithCalloutBuilder implements IPropertyPaneField<IPrope
     }
 
     private _onChanged(value: number): void {
+        const props: IPropertyFieldSliderWithCalloutProps = <IPropertyFieldSliderWithCalloutProps>this.properties;
         if (this._onChangeCallback) {
+          props.debounce ?
+            this._debounce(() => { console.log(`Debounced after ${props.debounce}`) ;this._onChangeCallback(this.targetProperty, value); }, props.debounce):
             this._onChangeCallback(this.targetProperty, value);
         }
     }

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -533,6 +533,19 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   showValue: true,
                   value: this.properties.sliderWithCalloutValue
                 }),
+                PropertyFieldSliderWithCallout('sliderWithCalloutValue', {
+                  calloutContent: React.createElement('div', {}, 'Enter value for the item'),
+                  calloutTrigger: CalloutTriggers.Click,
+                  calloutWidth: 200,
+                  key: 'sliderWithCalloutFieldId',
+                  label: 'Slide to select the value with debounce 1000',
+                  max: 100,
+                  min: 0,
+                  step: 1,
+                  showValue: true,
+                  value: this.properties.sliderWithCalloutValue,
+                  debounce: 1000
+                }),
                 PropertyFieldChoiceGroupWithCallout('choiceGroupWithCalloutValue', {
                   calloutContent: React.createElement('div', {}, 'Select preferrable mobile platform'),
                   calloutTrigger: CalloutTriggers.Hover,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

PR contains the updated PropertyFieldSliderWithCallout with debounce property, that allows to control when the onChanged trigger will be called.
