### PR TITLE
updated export link attribute

### DIFF
--- a/src/propertyFields/propertyEditor/PropertyPanePropertyEditorHost.tsx
+++ b/src/propertyFields/propertyEditor/PropertyPanePropertyEditorHost.tsx
@@ -100,6 +100,7 @@ export default class PropertyPanePropertyEditorHost extends React.Component<IPro
         const a = document.createElement("a");
         document.body.appendChild(a);
         a.setAttribute("style", "display: none");
+        a.setAttribute("data-interception", "off");
         const json = JSON.stringify(JSON.parse(this.state.propertiesJson), null, '\t'); // remove indentation
         const blob = new Blob([json], { type: "octet/stream" });
         const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
updated export link attribute to properly download blob from PropertyPanePropertyEditor.

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #210 

#### What's in this Pull Request?

Adds an attribute to the link created by the download button to avoid the Sharepoint link interceptor

